### PR TITLE
put the token in the header for delete operations

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -338,13 +338,9 @@ Retry:
 
 ## Unlock file
 
-unlock the file again after the file and the meta data was updated correctly
+unlock the file again after the file and the meta data was updated correctly. The token needs to be added to the header, see example below
 
 DELETE: `<base-url>/lock/<file-id>`
-
-**Data:**
-
-token: got during lock operation
 
 **Results:**
 
@@ -372,7 +368,7 @@ token: got during lock operation
 
 First try:
 
-`curl -X DELETE https://<user>:<password>@nextcloud/ocs/v2.php/apps/end_to_end_encryption/api/v1/lock/10 -d token="<token-from-lock>" -H "OCS-APIRequest:true"`
+`curl -X DELETE https://<user>:<password>@nextcloud/ocs/v2.php/apps/end_to_end_encryption/api/v1/lock/10 -H "OCS-APIRequest:true" -H "token:<token-received-during-lock-operation>`
 
 ## Store meta-data file
 

--- a/lib/Controller/RequestHandlerController.php
+++ b/lib/Controller/RequestHandlerController.php
@@ -477,13 +477,13 @@ class RequestHandlerController extends OCSController {
 	 * @NoAdminRequired
 	 *
 	 * @param int $id file ID
-	 * @param string $token token to identify client
 	 *
 	 * @return DataResponse
 	 * @throws OCSNotFoundException
 	 * @throws OCSForbiddenException
 	 */
-	public function unlockFolder($id, $token) {
+	public function unlockFolder($id) {
+		$token = $this->request->getHeader('token');
 		try {
 			$this->lockManager->unlockFile($id, $token);
 		} catch (FileLockedException $e) {


### PR DESCRIPTION
While some clients/servers support it, it is not really allowed or recommended to have a body for delete operations, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE

Therefore we add the access token to the header.

cc @tobiasKaminsky @rullzer @marinofaggiana 