### PR TITLE
check min version of clients

### DIFF
--- a/lib/UserAgentManager.php
+++ b/lib/UserAgentManager.php
@@ -28,6 +28,7 @@ class UserAgentManager {
 
 	/**
 	 * list of user agents that support end-to-end encryption
+	 * ['regex-to-identify-user-agent' => 'min-version']
 	 *
 	 * @var array
 	 */
@@ -35,9 +36,9 @@ class UserAgentManager {
 
 	public function __construct() {
 		$this->supportedUserAgents = [
-			Request::USER_AGENT_CLIENT_ANDROID,
-			Request::USER_AGENT_CLIENT_DESKTOP,
-			Request::USER_AGENT_CLIENT_IOS
+			'/^Mozilla\/5\.0 \(Android\) Nextcloud\-android.*$/' => '',
+			Request::USER_AGENT_CLIENT_DESKTOP => '',
+			Request::USER_AGENT_CLIENT_IOS => '',
 		];
 	}
 
@@ -48,13 +49,36 @@ class UserAgentManager {
 	 * @return bool
 	 */
 	public function supportsEndToEndEncryption($client) {
-		foreach ($this->supportedUserAgents as $regex) {
+		foreach ($this->supportedUserAgents as $regex => $minVersion) {
 			if (preg_match($regex, $client)) {
-				return true;
+				return $this->checkVersion($client, $minVersion);
 			}
 		}
 
 		return false;
+	}
+
+	/**
+	 * check the client version
+	 *
+	 * @param string $client
+	 * @param string $minVersion
+	 * @return bool returns true if clientVersion >= minVersion or if no min Version is specified
+	 */
+	protected function checkVersion($client, $minVersion) {
+
+		// no minVersion given, all client versions are compatible
+		if (empty($minVersion)) {
+			return true;
+		}
+
+		$version = substr( strrchr( $client, '/' ), 1 );
+		if(!empty($version) && version_compare($version, $minVersion) > -1) {
+			return true;
+		}
+
+		return false;
+
 	}
 
 }

--- a/lib/UserAgentManager.php
+++ b/lib/UserAgentManager.php
@@ -38,7 +38,7 @@ class UserAgentManager {
 		$this->supportedUserAgents = [
 			'/^Mozilla\/5\.0 \(Android\) Nextcloud\-android.*$/' => '',
 			Request::USER_AGENT_CLIENT_DESKTOP => '',
-			Request::USER_AGENT_CLIENT_IOS => '',
+			'/^Mozilla\/5\.0 \(iOS\) Nextcloud\-iOS.*$/' => '2.20.0',
 		];
 	}
 

--- a/tests/Unit/UserAgentManagerTest.php
+++ b/tests/Unit/UserAgentManagerTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @copyright Copyright (c) 2017 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\EndToEndEncryption\Tests\Unit;
+
+
+use OCA\EndToEndEncryption\UserAgentManager;
+use Test\TestCase;
+
+class UserAgentManagerTest extends TestCase {
+
+	/** @var UserAgentManager */
+	private $userAgentManager;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->userAgentManager = new UserAgentManager();
+	}
+
+	/**
+	 * @dataProvider dataTestCheckVersion
+	 *
+	 * @param string $client
+	 * @param string $minVersion
+	 * @param bool $expected
+	 */
+	public function testCheckVersion($client, $minVersion, $expected) {
+		$result = $this->invokePrivate($this->userAgentManager, 'checkVersion', [$client, $minVersion]);
+		$this->assertSame($expected, $result);
+	}
+
+	public function dataTestCheckVersion() {
+		return [
+			['Mozilla/5.0 (Android) Nextcloud-android/2.1.3', '', true],
+			['Mozilla/5.0 (Android) Nextcloud-android/2.1.3', '1.9.3', true],
+			['Mozilla/5.0 (Android) Nextcloud-android/2.1.3', '2.1.3', true],
+			['Mozilla/5.0 (Android) Nextcloud-android/2.1.3', '2.1.4', false],
+			// no valid version should result in false
+			['Mozilla/5.0 (Android) Nextcloud-android/', '2.1.4', false],
+			['Mozilla/5.0 (Android) Nextcloud-android/zzz', '2.1.4', false],
+		];
+	}
+
+
+}


### PR DESCRIPTION
Check client version to decide if the client is able to do end-to-end encryption or not.

@tobiasKaminsky right now I don't check the version for the Android client explicitly, because we can probably say that all clients who has "Nextcloud" in the user agent string can handle e2e. But if you prefer you can also tell me the min version

@marinofaggiana Can you tell me already the client version which will be able to do e2e on iOS? Then I can also check for iOS that no older clients try to access e2e encrypted files. Another question. How does the user Agent string looks like for the iOS client? The regex is defined this way `/^Mozilla\/5\.0 \(iOS\) (ownCloud|Nextcloud)\-iOS.*$/`. Do you still use 'ownCloud' as part of the user agent string or only Nextcloud? Because in this case I could check explicitly for Nextcloud, like I'm doing it for Android.

@rullzer do you already know the version number of the desktop client? Then I can add this as well.