### PR TITLE
Get the path from the node not the request

### DIFF
--- a/lib/Connector/Sabre/LockPlugin.php
+++ b/lib/Connector/Sabre/LockPlugin.php
@@ -116,7 +116,7 @@ class LockPlugin extends ServerPlugin {
 
 		$userAgent = $request->getHeader('user-agent');
 
-		$this->checkUserAgent($userAgent, $request->getPath());
+		$this->checkUserAgent($userAgent, $node->getPath());
 		if ($request->getMethod() === 'GET') {
 			if ($this->lockManager->isLocked($node->getId(), '')) {
 				throw new FileLocked('file is locked', Http::STATUS_FORBIDDEN);


### PR DESCRIPTION
The location in the dav endpont is `files/<user>`. So checking if the path
is valid and obtaining the Node (via node api) will fail. Since there
most likely isn't a folder `files/<user>`. We should instead use the path
of the node we have.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>
  