### PR TITLE
Make key storage and meta data handling more generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This app provides all the necessary APIs to implement end-to-end encryption
 on the client side. Additionally it makes sure that end-to-end encrypted
 files are not accessible with the web interface and other WebDAV clients.
 
+You can replace the key storage with your own implementation by implementing
+the OCA\EndToEndEncryption\IKeyStorage interface and set it in the config.php:
+
+`'e2e_encryption_key_storage' => '\OCA\MyApp\MyKeyStorage',`
+
 Here you can find the [API documentation](https://github.com/nextcloud/end_to_end_encryption/blob/master/doc/api.md).
 
 ![](doc/screenshots/e2ee-files-listing.png)

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -56,7 +56,7 @@ class Application extends App {
 			$request = $this->getContainer()->getServer()->getRequest();
 			$userAgentManager = $this->getContainer()->query(UserAgentManager::class);
 			$urlGenerator = \OC::$server->getURLGenerator();
-			$event->getServer()->addPlugin(new LockPlugin($rootFolder, $userSession, $lockManager, $userAgentManager, $urlGenerator));
+			$event->getServer()->addPlugin(new LockPlugin($rootFolder, $userSession, $lockManager, $userAgentManager, $urlGenerator, $this->getContainer(), \OC::$server->getConfig()));
 			$event->getServer()->addPlugin(new PropFindPlugin($userAgentManager, $request));
 		});
 

--- a/lib/Controller/RequestHandlerController.php
+++ b/lib/Controller/RequestHandlerController.php
@@ -36,6 +36,7 @@ use OCA\EndToEndEncryption\LockManager;
 use OCA\EndToEndEncryption\MetaDataStorage;
 use OCA\EndToEndEncryption\SignatureHandler;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
@@ -43,6 +44,7 @@ use OCP\AppFramework\OCSController;
 use OCP\Files\ForbiddenException;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IRequest;
@@ -98,23 +100,26 @@ class RequestHandlerController extends OCSController {
 	public function __construct($AppName,
 								IRequest $request,
 								$UserId,
-								KeyStorage $keyStorage,
 								MetaDataStorage $metaDataStorage,
 								SignatureHandler $signatureHandler,
 								EncryptionManager $manager,
 								LockManager $lockManager,
 								ILogger $logger,
-								IL10N $l
+								IL10N $l,
+								IAppContainer $appContainer,
+								IConfig $config
 	){
 		parent::__construct($AppName, $request);
 		$this->userId = $UserId;
-		$this->keyStorage = $keyStorage;
 		$this->metaDataStorage = $metaDataStorage;
 		$this->signatureHandler = $signatureHandler;
 		$this->manager = $manager;
 		$this->logger = $logger;
 		$this->lockManager = $lockManager;
 		$this->l = $l;
+
+		$keyStorage = $config->getSystemValue('e2e_encryption_key_storage', KeyStorage::class);
+		$this->keyStorage = $appContainer->query($keyStorage);
 	}
 
 	/**

--- a/lib/Controller/RequestHandlerController.php
+++ b/lib/Controller/RequestHandlerController.php
@@ -33,6 +33,7 @@ use OCA\EndToEndEncryption\Exceptions\MetaDataExistsException;
 use OCA\EndToEndEncryption\Exceptions\MissingMetaDataException;
 use OCA\EndToEndEncryption\KeyStorage;
 use OCA\EndToEndEncryption\LockManager;
+use OCA\EndToEndEncryption\MetaDataStorage;
 use OCA\EndToEndEncryption\SignatureHandler;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\OCS\OCSBadRequestException;
@@ -62,6 +63,9 @@ class RequestHandlerController extends OCSController {
 	/** @var KeyStorage */
 	private $keyStorage;
 
+	/** @var MetaDataStorage */
+	private $metaDataStorage;
+
 	/** @var SignatureHandler */
 	private $signatureHandler;
 
@@ -84,6 +88,7 @@ class RequestHandlerController extends OCSController {
 	 * @param IRequest $request
 	 * @param string $UserId
 	 * @param KeyStorage $keyStorage
+	 * @param MetaDataStorage $metaDataStorage
 	 * @param SignatureHandler $signatureHandler
 	 * @param EncryptionManager $manager
 	 * @param LockManager $lockManager
@@ -94,6 +99,7 @@ class RequestHandlerController extends OCSController {
 								IRequest $request,
 								$UserId,
 								KeyStorage $keyStorage,
+								MetaDataStorage $metaDataStorage,
 								SignatureHandler $signatureHandler,
 								EncryptionManager $manager,
 								LockManager $lockManager,
@@ -103,6 +109,7 @@ class RequestHandlerController extends OCSController {
 		parent::__construct($AppName, $request);
 		$this->userId = $UserId;
 		$this->keyStorage = $keyStorage;
+		$this->metaDataStorage = $metaDataStorage;
 		$this->signatureHandler = $signatureHandler;
 		$this->manager = $manager;
 		$this->logger = $logger;
@@ -302,7 +309,7 @@ class RequestHandlerController extends OCSController {
 	 */
 	public function getMetaData($id) {
 		try {
-			$metaData = $this->keyStorage->getMetaData($id);
+			$metaData = $this->metaDataStorage->getMetaData($id);
 		} catch (NotFoundException $e) {
 			throw new OCSNotFoundException($this->l->t('Could not find metadata for "%s"', [$id]));
 		} catch (\Exception $e) {
@@ -327,7 +334,7 @@ class RequestHandlerController extends OCSController {
 	 */
 	public function setMetaData($id, $metaData) {
 		try {
-			$this->keyStorage->setMetaData($id, $metaData);
+			$this->metaDataStorage->setMetaData($id, $metaData);
 		} catch (MetaDataExistsException $e) {
 			return new DataResponse([], Http::STATUS_CONFLICT);
 		} catch (NotFoundException $e) {
@@ -362,7 +369,7 @@ class RequestHandlerController extends OCSController {
 		}
 
 		try {
-			$this->keyStorage->updateMetaData($id, $metaData);
+			$this->metaDataStorage->updateMetaData($id, $metaData);
 		} catch (MissingMetaDataException $e) {
 			throw new OCSNotFoundException($this->l->t("Metadata-file doesn\'t exist"));
 		} catch (NotFoundException $e) {
@@ -390,7 +397,7 @@ class RequestHandlerController extends OCSController {
 	 */
 	public function deleteMetaData($id) {
 		try {
-			$this->keyStorage->deleteMetaData($id);
+			$this->metaDataStorage->deleteMetaData($id);
 		} catch (NotFoundException $e) {
 			throw new OCSNotFoundException($this->l->t('Could not find metadata for "%s"', [$id]));
 		} catch (NotPermittedException $e) {

--- a/lib/IKeyStorage.php
+++ b/lib/IKeyStorage.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\EndToEndEncryption;
+
+interface IKeyStorage {
+
+	/**
+	 * store public key
+	 *
+	 * @param string $publicKey
+	 * @param string $uid
+	 * @return bool
+	 *
+	 * @throws \Exception
+	 */
+	public function setPublicKey($publicKey, $uid);
+
+	/**
+	 * check if a public key exists
+	 *
+	 * @param string $uid
+	 * @return bool
+	 */
+	public function publicKeyExists($uid);
+
+	/**
+	 * get users public key
+	 *
+	 * @param string $uid
+	 * @return string
+	 *
+	 * @throws \RuntimeException
+	 * @throws NotFoundException
+	 */
+	public function getPublicKey($uid);
+
+
+	/**
+	 * delete the users public key
+	 *
+	 * @param string $uid
+	 * @return bool
+	 *
+	 * @throws NotPermittedException
+	 * @throws \RuntimeException
+	 * @throws NotFoundException
+	 */
+	public function deletePublicKey($uid);
+
+
+	/**
+	 * store private key
+	 *
+	 * @param string $privateKey
+	 * @param string $uid
+	 * @return bool
+	 *
+	 * @throw KeyExistsException
+	 */
+	public function setPrivateKey($privateKey, $uid);
+
+
+	/**
+	 * get users private key
+	 *
+	 * @param string $uid
+	 * @return string
+	 *
+	 * @throws \RuntimeException
+	 * @throws NotFoundException
+	 * @throws ForbiddenException
+	 */
+	public function getPrivateKey($uid);
+
+	/**
+	 * get users private key
+	 *
+	 * @param string $uid
+	 * @return bool
+	 *
+	 * @throws NotPermittedException
+	 * @throws \RuntimeException
+	 * @throws NotFoundException
+	 */
+	public function deletePrivateKey($uid);
+	/**
+	 * delete all user private and public key permanently
+	 *
+	 * @param IUser $user
+	 */
+	public function deleteUserKeys(IUser $user);
+
+}

--- a/lib/IKeyStorage.php
+++ b/lib/IKeyStorage.php
@@ -25,6 +25,9 @@ use OCP\IUser;
 
 interface IKeyStorage {
 
+	const CLIENT_ACCESS = 1;
+	const WEB_ACCESS = 2;
+
 	/**
 	 * store public key
 	 *
@@ -110,5 +113,13 @@ interface IKeyStorage {
 	 * @param IUser $user
 	 */
 	public function deleteUserKeys(IUser $user);
+
+	/**
+	 * Get capabilities of the key storage, e.g. can keys be accessed by the web
+	 * interface
+	 *
+	 * @return array
+	 */
+	public function getCapabilities();
 
 }

--- a/lib/IKeyStorage.php
+++ b/lib/IKeyStorage.php
@@ -21,6 +21,8 @@
 
 namespace OCA\EndToEndEncryption;
 
+use OCP\IUser;
+
 interface IKeyStorage {
 
 	/**

--- a/lib/KeyStorage.php
+++ b/lib/KeyStorage.php
@@ -298,4 +298,9 @@ class KeyStorage implements IKeyStorage {
 		}
 
 	}
+
+	public function getCapabilities() {
+		return IKeyStorage::CLIENT_ACCESS;
+	}
+
 }

--- a/lib/KeyStorage.php
+++ b/lib/KeyStorage.php
@@ -41,7 +41,7 @@ use OCP\IUserSession;
  *
  * @package OCA\EndToEndEncryption
  */
-class KeyStorage {
+class KeyStorage implements IKeyStorage {
 
 	/** @var  IAppData */
 	private $appData;

--- a/lib/MetaDataStorage.php
+++ b/lib/MetaDataStorage.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Bjoern Schiessle <bjoern@schiessle.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\EndToEndEncryption;
+
+
+use OCA\EndToEndEncryption\Exceptions\MetaDataExistsException;
+use OCA\EndToEndEncryption\Exceptions\MissingMetaDataException;
+use OCP\Files\IAppData;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\ILogger;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+
+/**
+ * Class KeyStorage
+ *
+ * read and write encryption keys to the server
+ *
+ * @package OCA\EndToEndEncryption
+ */
+class MetaDataStorage {
+
+	/** @var  IAppData */
+	private $appData;
+
+	/** @var IUserSession */
+	private $userSession;
+
+	/** @var ILogger */
+	private $logger;
+
+	/** @var IRootFolder */
+	private $rootFolder;
+
+	/** @var IUserManager */
+	private $userManager;
+
+	/** @var string */
+	private $privateKeysRoot = '/private-keys';
+
+	/** @var string */
+	private $publicKeysRoot = '/public-keys';
+
+	/** @var string */
+	private $metaDataRoot = '/meta-data';
+
+	/** @var string */
+	private $metaDataFileName = 'meta.data';
+
+	/**
+	 * KeyStorage constructor.
+	 *
+	 * @param IAppData $appData
+	 * @param IUserSession $userSession
+	 * @param ILogger $logger
+	 * @param IRootFolder $rootFolder
+	 * @param IUserManager $userManager
+	 */
+	public function __construct(IAppData $appData,
+								IUserSession $userSession,
+								ILogger $logger,
+								IRootFolder $rootFolder,
+								IUserManager $userManager
+	) {
+		$this->appData = $appData;
+		$this->userSession = $userSession;
+		$this->logger = $logger;
+		$this->rootFolder = $rootFolder;
+		$this->userManager = $userManager;
+		$this->checkFolderStructure();
+	}
+
+	private function checkFolderStructure() {
+		$metaDataStorageRoot = $this->appData->getFolder('/');
+		if (!$metaDataStorageRoot->fileExists($this->metaDataRoot)) {
+			$this->appData->newFolder($this->metaDataRoot);
+		}
+	}
+
+	/**
+	 * create target folder recursively
+	 *
+	 * @param string $path
+	 * @param $root
+	 *
+	 * @throws \Exception
+	 */
+	private function prepareTargetFolder($path, $root) {
+		try {
+			$node = $this->appData->getFolder($root);
+			// create folder structure recursively
+			if (!$node->fileExists($path)) {
+				$sub_dirs = explode('/', ltrim($path, '/'));
+				$dir = '';
+				foreach ($sub_dirs as $sub_dir) {
+					$dir .= '/' . $sub_dir;
+					if (!$node->fileExists($dir)) {
+						$this->appData->newFolder($root . $dir);
+					}
+				}
+			}
+		} catch (\Exception $e) {
+			$error = 'Can\'t prepare target folders: ' . $e->getMessage();
+			$this->logger->error($error, ['app' => 'end_to_end_encryption']);
+			throw $e;
+		}
+	}
+
+
+	/**
+	 * get meta data file
+	 *
+	 * @param int $id
+	 * @return string
+	 *
+	 * @throws NotFoundException
+	 * @throws \RuntimeException
+	 * @throws NotPermittedException
+	 */
+	public function getMetaData($id) {
+		$path = $this->getOwnerPath($id);
+		$folder = $this->appData->getFolder($this->metaDataRoot . '/' . $path);
+		$file = $folder->getFile($this->metaDataFileName);
+		return $file->getContent();
+	}
+
+	/**
+	 * delete meta data file
+	 *
+	 * @param int $id
+	 *
+	 * @throws \RuntimeException
+	 * @throws NotPermittedException
+	 * @throws NotFoundException
+	 */
+	public function deleteMetaData($id) {
+		$owner = $this->getOwner($id);
+		$currentUser = $this->userSession->getUser();
+		if ($owner->getUID() !== $currentUser->getUID()) {
+			throw new NotPermittedException();
+		}
+
+		$path = $this->getOwnerPath($id);
+		$folder = $this->appData->getFolder($this->metaDataRoot . '/' . $path);
+		$folder->getFile($this->metaDataFileName)->delete();
+	}
+
+
+	/**
+	 * set meta data file
+	 *
+	 * @param int $id file id
+	 * @param string $metaData
+	 *
+	 * @throws NotPermittedException
+	 * @throws NotFoundException
+	 * @throws \RuntimeException
+	 * @throws \Exception
+	 * @throws MetaDataExistsException
+	 */
+	public function setMetaData($id, $metaData) {
+		$path = $this->getOwnerPath($id);
+		$this->prepareTargetFolder($path, $this->metaDataRoot);
+		$dir = $this->appData->getFolder($this->metaDataRoot . '/' . $path);
+		if ($dir->fileExists($this->metaDataFileName)) {
+			throw new MetaDataExistsException('meta data file already exists');
+		}
+
+		$file = $dir->newFile($this->metaDataFileName);
+		$file->putContent($metaData);
+	}
+
+
+	/**
+	 * delete all meta data files for a given user, e.g. when the user was deleted
+	 *
+	 * @param IUser $user
+	 * @throws NotPermittedException
+	 */
+	public function deleteAllMetaDataFiles(IUser $user) {
+		$uid = $user->getUID();
+		if(!$this->userManager->userExists($uid)) {
+			try {
+				$metaDataRoot = $this->appData->getFolder($this->metaDataRoot . '/' . $uid);
+				$metaDataRoot->delete();
+			} catch (NotFoundException $e) {
+				// do nothing if no meta data exists
+			}
+		}
+	}
+
+	/**
+	 * update meta data file
+	 *
+	 * @param int $id file id
+	 * @param string $fileKey
+	 *
+	 * @throws NotPermittedException
+	 * @throws NotFoundException
+	 * @throws \RuntimeException
+	 * @throws \Exception
+	 * @throws MissingMetaDataException
+	 */
+	public function updateMetaData($id, $fileKey) {
+		// ToDo check signature for race condition
+		$path = $this->getOwnerPath($id);
+		$this->prepareTargetFolder($path, $this->metaDataRoot);
+		$dir = $this->appData->getFolder($this->metaDataRoot . '/' . $path);
+		if (!$dir->fileExists($this->metaDataFileName)) {
+			throw new MissingMetaDataException('meta data file missing');
+		}
+
+		$file = $dir->getFile($this->metaDataFileName);
+		$file->putContent($fileKey);
+	}
+
+	/**
+	 * get path to the file for the file-owner
+	 *
+	 * @param int $id file id
+	 * @return string path to the owner's file
+	 *
+	 * @throws NotFoundException
+	 */
+	private function getOwnerPath($id) {
+		$node = $this->rootFolder->getById($id);
+		if (!isset($node[0])) {
+			throw new NotFoundException('No file with ID ' . $id);
+		}
+		$owner = $node[0]->getOwner();
+		$ownerRoot = $this->rootFolder->getUserFolder($owner->getUID());
+		$node = $ownerRoot->getById($id);
+		if (!isset($node[0])) {
+			throw new NotFoundException('No file for owner with ID ' . $id);
+		}
+		return $node[0]->getPath();
+	}
+
+	/**
+	 * get owner
+	 *
+	 * @param int $id file id
+	 * @return IUser
+	 * @throws NotFoundException
+	 */
+	private function getOwner($id) {
+		$node = $this->rootFolder->getById($id);
+		if (!isset($node[0])) {
+			throw new NotFoundException('No file with ID ' . $id);
+		}
+		$owner = $node[0]->getOwner();
+
+		return $owner;
+	}
+}


### PR DESCRIPTION
Seperate meta data handling form key handling and allow to write your own key handling class to enable integration in various systems.

@MaxFichtelmann your KeyStorage class can now implement the IKeyStorage interface after this was merged and released. I separated the meta data handling from the key handling, so you can remove trhe methods for the meta data. Additionally you have to add this method:

````
	public function getCapabilities() {
		return OCA\EndToEndEncryption\IKeyStorage::CLIENT_ACCESS | OCA\EndToEndEncryption\IKeyStorage::WEB_ACCESS;
	}
````