### PR TITLE
MetaData: Use FileId instead of Path

### DIFF
--- a/lib/UserManager.php
+++ b/lib/UserManager.php
@@ -47,6 +47,5 @@ class UserManager {
 	 */
 	public function deleteUserKeys(IUser $user): void {
 		$this->keyStorage->deleteUserKeys($user);
-		$this->keyStorage->deleteAllMetaDataFiles($user);
 	}
 }


### PR DESCRIPTION
fixes #143 

MetaData management has many problems, when you move / rename an e2e folders (or any of it's parent folders), the metadata key gets lost, because the path changed and the change is not reflected in appdata.

Solution: Just use fileId instead.