### PR TITLE
LockMapper fixes

### DIFF
--- a/lib/LockManager.php
+++ b/lib/LockManager.php
@@ -60,8 +60,6 @@ class LockManager {
 	/** @var ITimeFactory */
 	private $timeFactory;
 
-	private $validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-
 	/**
 	 * LockManager constructor.
 	 *
@@ -181,6 +179,6 @@ class LockManager {
 	 * @return string
 	 */
 	private function getToken(): string {
-		return $this->secureRandom->generate(64, $this->validChars);
+		return $this->secureRandom->generate(64, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
 	}
 }

--- a/lib/LockManager.php
+++ b/lib/LockManager.php
@@ -33,6 +33,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IUserSession;
 use OCP\Security\ISecureRandom;
 
@@ -144,9 +145,14 @@ class LockManager {
 	 * @return bool
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
+	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function isLocked(int $id, string $token): bool {
 		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new NotPermittedException('No active user-session');
+		}
+
 		$userRoot = $this->rootFolder->getUserFolder($user->getUID());
 		$nodes = $userRoot->getById($id);
 		foreach ($nodes as $node) {

--- a/lib/LockManager.php
+++ b/lib/LockManager.php
@@ -29,6 +29,7 @@ use OCA\EndToEndEncryption\Db\LockMapper;
 use OCA\EndToEndEncryption\Exceptions\FileLockedException;
 use OCA\EndToEndEncryption\Exceptions\FileNotLockedException;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -56,6 +57,9 @@ class LockManager {
 	/** @var IRootFolder */
 	private $rootFolder;
 
+	/** @var ITimeFactory */
+	private $timeFactory;
+
 	private $validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
 	/**
@@ -65,16 +69,19 @@ class LockManager {
 	 * @param ISecureRandom $secureRandom
 	 * @param IRootFolder $rootFolder
 	 * @param IUserSession $userSession
+	 * @param ITimeFactory $timeFactory
 	 */
 	public function __construct(LockMapper $lockMapper,
 								ISecureRandom $secureRandom,
 								IRootFolder $rootFolder,
-								IUserSession $userSession
+								IUserSession $userSession,
+								ITimeFactory $timeFactory
 	) {
 		$this->lockMapper = $lockMapper;
 		$this->secureRandom = $secureRandom;
 		$this->userSession = $userSession;
 		$this->rootFolder = $rootFolder;
+		$this->timeFactory = $timeFactory;
 	}
 
 	/**
@@ -95,7 +102,7 @@ class LockManager {
 			$newToken = $this->getToken();
 			$lockEntity = new Lock();
 			$lockEntity->setId($id);
-			$lockEntity->setTimestamp($this->getTimestamp());
+			$lockEntity->setTimestamp($this->timeFactory->getTime());
 			$lockEntity->setToken($newToken);
 			$this->lockMapper->insert($lockEntity);
 			return $newToken;
@@ -175,14 +182,5 @@ class LockManager {
 	 */
 	private function getToken(): string {
 		return $this->secureRandom->generate(64, $this->validChars);
-	}
-
-	/**
-	 * get timestamp of current time
-	 *
-	 * @return int
-	 */
-	protected function getTimestamp(): int {
-		return time();
 	}
 }

--- a/tests/Unit/Db/LockMapperTest.php
+++ b/tests/Unit/Db/LockMapperTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2020 Georg Ehrke <georg-nextcloud@ehrke.email>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\EndToEndEncryption\Tests\Unit\Db;
+
+use OCA\EndToEndEncryption\Db\Lock;
+use OCA\EndToEndEncryption\Db\LockMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use Test\TestCase;
+
+class LockMapperTest extends TestCase {
+
+	/** @var LockMapper */
+	private $lockMapper;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// make sure that DB is empty
+		$qb = self::$realDatabase->getQueryBuilder();
+		$qb->delete('e2e_encryption_lock')->execute();
+
+		$this->lockMapper = new LockMapper(self::$realDatabase);
+	}
+
+	/**
+	 * @Db
+	 */
+	public function testGetByFileId(): void {
+		$lock1 = new Lock();
+		$lock1->setId(1);
+		$lock1->setTimestamp(123);
+		$lock1->setToken('token123');
+
+		$lock2 = new Lock();
+		$lock2->setId(2);
+		$lock2->setTimestamp(456);
+		$lock2->setToken('token456');
+
+		$this->lockMapper->insert($lock1);
+		$this->lockMapper->insert($lock2);
+
+		$actualLock = $this->lockMapper->getByFileId(2);
+
+		$this->assertEquals($lock2->getId(), $actualLock->getId());
+		$this->assertEquals($lock2->getTimestamp(), $actualLock->getTimestamp());
+		$this->assertEquals($lock2->getToken(), $actualLock->getToken());
+	}
+
+	/**
+	 * @Db
+	 */
+	public function testGetTableName(): void {
+		$this->assertEquals('e2e_encryption_lock', $this->lockMapper->getTableName());
+	}
+
+	/**
+	 * @Db
+	 */
+	public function testInsertUpdateDelete(): void {
+		$lock1 = new Lock();
+		$lock1->setId(1);
+		$lock1->setTimestamp(123);
+		$lock1->setToken('token123');
+
+		$lock2 = new Lock();
+		$lock2->setId(2);
+		$lock2->setTimestamp(456);
+		$lock2->setToken('token456');
+
+		$lock3 = new Lock();
+		$lock3->setId(3);
+		$lock3->setTimestamp(789);
+		$lock3->setToken('token789');
+
+		$lock4 = new Lock();
+		$lock4->setId(4);
+		$lock4->setTimestamp(123456);
+		$lock4->setToken('token123456');
+
+		$this->lockMapper->insert($lock1);
+		$this->lockMapper->insert($lock2);
+		$this->lockMapper->insert($lock3);
+		$this->lockMapper->insert($lock4);
+
+		$testLock = $this->lockMapper->getByFileId(3);
+		$this->assertEquals(789, $testLock->getTimestamp());
+
+		$testLock->setTimestamp(789123456);
+		$this->lockMapper->update($testLock);
+
+		$testLock2 = $this->lockMapper->getByFileId(3);
+		$this->assertEquals(789123456, $testLock2->getTimestamp());
+
+		$this->lockMapper->delete($testLock2);
+
+		$this->expectException(DoesNotExistException::class);
+		$this->lockMapper->getByFileId(3);
+	}
+}


### PR DESCRIPTION
fixes #148 

Minor changes to improve testability, no logic changes.

tl;dr:
- use `ITimeFactory` instead of `time()`
- use `ISecureRandom` consts
- add real unit tests