### PR TITLE
Fix an issue of PropFindPlugin being called too early.

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,6 +10,7 @@
     <author>Bjoern Schiessle</author>
     <namespace>EndToEndEncryption</namespace>
     <types>
+        <dav/>
         <filesystem/>
     </types>
     <category>files</category>

--- a/lib/Connector/Sabre/PropFindPlugin.php
+++ b/lib/Connector/Sabre/PropFindPlugin.php
@@ -64,7 +64,7 @@ class PropFindPlugin extends APlugin {
 	public function initialize(Server $server) {
 		parent::initialize($server);
 
-		$this->server->on('propFind', [$this, 'updateProperty']);
+		$this->server->on('propFind', [$this, 'updateProperty'], 105);
 	}
 
 	/**

--- a/tests/Unit/Connector/Sabre/PropFindPluginTest.php
+++ b/tests/Unit/Connector/Sabre/PropFindPluginTest.php
@@ -70,7 +70,7 @@ class PropFindPluginTest extends TestCase {
 
 		$server->expects($this->at(0))
 			->method('on')
-			->with('propFind', [$this->plugin, 'updateProperty']);
+			->with('propFind', [$this->plugin, 'updateProperty'], 105);
 
 		$this->plugin->initialize($server);
 	}

--- a/tests/Unit/Controller/KeyControllerTest.php
+++ b/tests/Unit/Controller/KeyControllerTest.php
@@ -251,8 +251,7 @@ AYzYQFPtjsDZ4Tju4VZKM4YpF2GwQgT7zhzDBvywGPqvfw==
 		} else {
 			$this->keyStorage->expects($this->once())
 				->method('setPrivateKey')
-				->with($privateKey, 'admin')
-				->willReturn($privateKey);
+				->with($privateKey, 'admin');
 		}
 
 		$this->l10n->expects($this->any())


### PR DESCRIPTION
PropFindPlugin was called, before the `{http://nextcloud.org/ns}is-encrypted` flag was set.