### PR TITLE
Unlock: Allow providing token as url query

### DIFF
--- a/lib/Controller/LockingController.php
+++ b/lib/Controller/LockingController.php
@@ -130,6 +130,9 @@ class LockingController extends OCSController {
 	 */
 	public function unlockFolder(int $id): DataResponse {
 		$token = $this->request->getHeader('e2e-token');
+		if ($token === '') {
+			$token = $this->request->getParam('e2e-token', '');
+		}
 
 		try {
 			$userFolder = $this->rootFolder->getUserFolder($this->userId);


### PR DESCRIPTION
@tobiasKaminsky You probably need this as well, as unlocking is using a `DELETE`.

This is also necessary for iOS, which is currently sending this:
```
172.18.0.1 - - [13/Aug/2020:09:03:14 +0000] "DELETE /nextcloud/ocs/v2.php/apps/end_to_end_encryption/api/v1/lock/9683?format=json&e2e-token=dPcWPOxdBGROZh3Eq32Yl48PvRfaAKB9GjgCc53j15gXiUMjVvokDRBNRb1tVi16 HTTP/1.1" 200 81 "-" "Mozilla/5.0 (iOS) Nextcloud-iOS/3.0.4"
```