### PR TITLE
Bump version to 1.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ source_dir=$(build_dir)/source
 sign_dir=$(build_dir)/sign
 package_name=$(app_name)
 cert_dir=$(HOME)/.nextcloud/certificates
-version+=1.5.1
+version+=1.6.1
 
 all: appstore
 


### PR DESCRIPTION
🚧 🚧 🚧 
Requires: #179 
🚧 🚧 🚧 