### PR TITLE
Update minimum client versions

### DIFF
--- a/lib/UserAgentManager.php
+++ b/lib/UserAgentManager.php
@@ -39,8 +39,8 @@ class UserAgentManager {
 	public function __construct() {
 		$this->supportedUserAgents = [
 			'/^Mozilla\/5\.0 \(Android\) Nextcloud\-android\/(?<version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)).*$/' => '3.13.0',
-			'/^Mozilla\/5\.0 \([A-Za-z ]+\) (mirall|csyncoC)\/(?<version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)).*$/' => '2.7.0',
-			'/^Mozilla\/5\.0 \(iOS\) Nextcloud\-iOS\/(?<version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)).*$/' => '3.0.0',
+			'/^Mozilla\/5\.0 \([A-Za-z ]+\) (mirall|csyncoC)\/(?<version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)).*$/' => '3.0.0',
+			'/^Mozilla\/5\.0 \(iOS\) Nextcloud\-iOS\/(?<version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)).*$/' => '3.0.5',
 		];
 	}
 


### PR DESCRIPTION
Updates Desktop to `3.0.0`, since there never was a `2.7.0` after all.
Updates iOS to `3.0.5` just to be sure to enforce the newest version.