### PR TITLE
Fixes Nextcloud server v21 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ source_dir=$(build_dir)/source
 sign_dir=$(build_dir)/sign
 package_name=$(app_name)
 cert_dir=$(HOME)/.nextcloud/certificates
-version+=1.6.1
+version+=1.8.0
 
 all: appstore
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@
     <repository type="git">https://github.com/nextcloud/end_to_end_encryption.git</repository>
     <screenshot>https://raw.githubusercontent.com/nextcloud/end_to_end_encryption/master/screenshots/e2ee-filelisting.png</screenshot>
     <dependencies>
-        <nextcloud min-version="22" max-version="22" />
+        <nextcloud min-version="21" max-version="22" />
     </dependencies>
 	<background-jobs>
 		<job>OCA\EndToEndEncryption\BackgroundJob\RollbackBackgroundJob</job>


### PR DESCRIPTION
End-to-End Encryption v1.6.2 (the current version available in the apps
repository) is not compatible with Nextcloud server v21 due to a
breaking change in the DBAL Types interface. This has been fixed in the
unreleased master branch, however the `appinfo/info.xml` file in that
branch lists v21 as the min-version supported of the Nextcloud server.

I have decremented min-version to v21 and tested on a local v21 server
based on the docker-compose v21 postgres deployment, as published by
nextcloud. E2EE installs and seems to work properly. I was able to setup
an encrypted folder, add some files, verify that they were (or at least
appeared to be) encrypted on the server, setup a second client, enter
the mnemonic, and read the encrypted files on the second client. I'd
hope to get this pushed to production as soon as possible to fix this
regression, but obviously given the sensitive nature, someone with more
experience should verify that the encryption does indeed work properly
on v21.