### PR TITLE
Cache end to end encrypted paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "cs:check": "php-cs-fixer fix --dry-run --diff",
         "cs:fix": "php-cs-fixer fix",
         "psalm": "psalm.phar --threads=1",
-		"psalm:update-baseline": "psalm.phar --threads=1 --update-baseline --set-baseline=tests/psalm-baseline.xml",
+		"psalm:update-baseline": "psalm.phar --threads=1 --update-baseline",
         "psalm:clear": "psalm.phar --clear-cache && psalm --clear-global-cache",
         "psalm:fix": "psalm.phar --alter --issues=InvalidReturnType,InvalidNullableReturnType,MissingParamType,InvalidFalsableReturnType",
         "test": "phpunit --configuration phpunit.xml --fail-on-warning",

--- a/composer.lock
+++ b/composer.lock
@@ -13,17 +13,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/nextcloud_composer.git",
-                "reference": "19c58278e072ef28bcce2370995b785aca350149"
+                "reference": "9f9f727cf66a75ece93cee24c01074a477e1615e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/19c58278e072ef28bcce2370995b785aca350149",
-                "reference": "19c58278e072ef28bcce2370995b785aca350149",
+                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/9f9f727cf66a75ece93cee24c01074a477e1615e",
+                "reference": "9f9f727cf66a75ece93cee24c01074a477e1615e",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ~8.0 || ~8.1",
-                "psr/container": "^1.0",
+                "psr/container": "^1.1.1",
                 "psr/event-dispatcher": "^1.0",
                 "psr/log": "^1.1"
             },
@@ -31,7 +31,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "24.0.0-dev"
+                    "dev-master": "25.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -49,7 +49,7 @@
                 "issues": "https://github.com/ChristophWurst/nextcloud_composer/issues",
                 "source": "https://github.com/ChristophWurst/nextcloud_composer/tree/master"
             },
-            "time": "2022-04-07T01:42:11+00:00"
+            "time": "2022-08-18T02:33:31+00:00"
         },
         {
             "name": "composer/pcre",
@@ -4250,5 +4250,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/lib/Connector/Sabre/APlugin.php
+++ b/lib/Connector/Sabre/APlugin.php
@@ -27,7 +27,6 @@ use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\File;
 use OCA\EndToEndEncryption\E2EEnabledPathCache;
-use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\IUserSession;
@@ -110,14 +109,7 @@ abstract class APlugin extends ServerPlugin {
 			throw new Forbidden('No user session found');
 		}
 		$uid = $user->getUID();
-
-		try {
-			return $this->rootFolder
-				->getUserFolder($uid)
-				->get($path);
-		} catch (Exception $e) {
-			throw new NotFound('file not found', Http::STATUS_NOT_FOUND, $e);
-		}
+		return $this->pathCache->getFileNode($uid, $path, $this->rootFolder);
 	}
 
 	/**
@@ -125,9 +117,9 @@ abstract class APlugin extends ServerPlugin {
 	 */
 	protected function isE2EEnabledPath(string $path): bool {
 		try {
-			 $node = $this->getFileNode($path);
+			$node = $this->getFileNode($path);
 		} catch (NotFound $e) {
-			 return false;
+			return false;
 		}
 		return $this->pathCache->isE2EEnabledPath($node, $path);
 	}
@@ -146,5 +138,4 @@ abstract class APlugin extends ServerPlugin {
 
 		return $this->applyPlugin[$url];
 	}
-
 }

--- a/lib/Connector/Sabre/APlugin.php
+++ b/lib/Connector/Sabre/APlugin.php
@@ -22,9 +22,7 @@ declare(strict_types=1);
  */
 namespace OCA\EndToEndEncryption\Connector\Sabre;
 
-use OCP\AppFramework\Http;
 use OCA\DAV\Connector\Sabre\Directory;
-use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\File;
 use OCA\EndToEndEncryption\E2EEnabledPathCache;
 use OCP\Files\IRootFolder;
@@ -100,28 +98,10 @@ abstract class APlugin extends ServerPlugin {
 	}
 
 	/**
-	 * Get file system node of requested file
-	 * @throws NotFound
-	 */
-	protected function getFileNode(string $path): Node {
-		$user = $this->userSession->getUser();
-		if ($user === null) {
-			throw new Forbidden('No user session found');
-		}
-		$uid = $user->getUID();
-		return $this->pathCache->getFileNode($uid, $path, $this->rootFolder);
-	}
-
-	/**
 	 * Checks if the path is an E2E folder or inside an E2E folder
 	 */
-	protected function isE2EEnabledPath(string $path): bool {
-		try {
-			$node = $this->getFileNode($path);
-		} catch (NotFound $e) {
-			return false;
-		}
-		return $this->pathCache->isE2EEnabledPath($node, $path);
+	protected function isE2EEnabledPath(\OCA\DAV\Connector\Sabre\Node $node): bool {
+		return $this->pathCache->isE2EEnabledPath($node->getNode());
 	}
 
 	/**

--- a/lib/Connector/Sabre/APlugin.php
+++ b/lib/Connector/Sabre/APlugin.php
@@ -26,6 +26,7 @@ use OCP\AppFramework\Http;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\File;
+use OCA\EndToEndEncryption\E2EEnabledPathCache;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
@@ -41,6 +42,7 @@ abstract class APlugin extends ServerPlugin {
 	protected ?Server $server = null;
 	protected IRootFolder $rootFolder;
 	protected IUserSession $userSession;
+	protected E2EEnabledPathCache $pathCache;
 
 	/**
 	 * Should plugin be applied to the current node?
@@ -50,14 +52,15 @@ abstract class APlugin extends ServerPlugin {
 
 	/**
 	 * APlugin constructor.
-	 *
-	 * @param IRootFolder $rootFolder
-	 * @param IUserSession $userSession
 	 */
-	public function __construct(IRootFolder $rootFolder,
-								IUserSession $userSession) {
+	public function __construct(
+		IRootFolder $rootFolder,
+		IUserSession $userSession,
+		E2EEnabledPathCache $pathCache
+	) {
 		$this->rootFolder = $rootFolder;
 		$this->userSession = $userSession;
+		$this->pathCache = $pathCache;
 	}
 
 	/**
@@ -118,6 +121,18 @@ abstract class APlugin extends ServerPlugin {
 	}
 
 	/**
+	 * Checks if the path is an E2E folder or inside an E2E folder
+	 */
+	protected function isE2EEnabledPath(string $path): bool {
+		try {
+			 $node = $this->getFileNode($path);
+		} catch (NotFound $e) {
+			 return false;
+		}
+		return $this->pathCache->isE2EEnabledPath($node, $path);
+	}
+
+	/**
 	 * Check if we process a file or directory. This plugin should ignore calendars
 	 * and contacts
 	 */
@@ -132,27 +147,4 @@ abstract class APlugin extends ServerPlugin {
 		return $this->applyPlugin[$url];
 	}
 
-	/**
-	 * Checks if the path is an E2E folder or inside an E2E folder
-	 */
-	protected function isE2EEnabledPath(string $path):bool {
-		try {
-			$node = $this->getFileNode($path);
-		} catch (NotFound $e) {
-			return false;
-		}
-
-		while ($node->isEncrypted() === false || $node->getType() === FileInfo::TYPE_FILE) {
-			$node = $node->getParent();
-
-			// Nitpick: This doesn't check if root is E2E,
-			// but that's not supported at the moment anyway
-			if ($node->getPath() === '/') {
-				// top-level folder reached
-				return false;
-			}
-		}
-
-		return true;
-	}
 }

--- a/lib/Connector/Sabre/LockPlugin.php
+++ b/lib/Connector/Sabre/LockPlugin.php
@@ -39,6 +39,7 @@ use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\INode;
 use Sabre\DAV\Server;
 use Sabre\HTTP\RequestInterface;
+use OCA\EndToEndEncryption\E2EEnabledPathCache;
 
 class LockPlugin extends APlugin {
 	private LockManager $lockManager;
@@ -47,8 +48,9 @@ class LockPlugin extends APlugin {
 	public function __construct(IRootFolder $rootFolder,
 								IUserSession $userSession,
 								LockManager $lockManager,
-								UserAgentManager $userAgentManager) {
-		parent::__construct($rootFolder, $userSession);
+								UserAgentManager $userAgentManager,
+								E2EEnabledPathCache $pathCache) {
+		parent::__construct($rootFolder, $userSession, $pathCache);
 		$this->lockManager = $lockManager;
 		$this->userAgentManager = $userAgentManager;
 	}

--- a/lib/Connector/Sabre/LockPlugin.php
+++ b/lib/Connector/Sabre/LockPlugin.php
@@ -98,21 +98,21 @@ class LockPlugin extends APlugin {
 			$destNode = $this->getNode($destInfo['destination'], $method);
 
 			if ($node instanceof FutureFile) {
-				if ($this->isE2EEnabledPath($destNode->getPath()) === false) {
+				if ($this->isE2EEnabledPath($destNode) === false) {
 					return;
 				}
 			} else {
 				// If neither is an end to end encrypted folders, we don't care
-				if (!$this->isE2EEnabledPath($node->getPath()) && !$this->isE2EEnabledPath($destNode->getPath())) {
+				if (!$this->isE2EEnabledPath($node) && !$this->isE2EEnabledPath($destNode)) {
 					return;
 				}
 
 				// Prevent moving or copying stuff from non-encrypted to encrypted folders
-				if ($this->isE2EEnabledPath($node->getPath()) xor $this->isE2EEnabledPath($destNode->getPath())) {
+				if ($this->isE2EEnabledPath($node) xor $this->isE2EEnabledPath($destNode)) {
 					throw new Forbidden('Cannot copy or move files from non-encrypted folders to end to end encrypted folders or vice versa.');
 				}
 			}
-		} elseif (!$this->isE2EEnabledPath($node->getPath())) {
+		} elseif (!$this->isE2EEnabledPath($node)) {
 			return;
 		}
 

--- a/lib/Connector/Sabre/PropFindPlugin.php
+++ b/lib/Connector/Sabre/PropFindPlugin.php
@@ -27,6 +27,7 @@ namespace OCA\EndToEndEncryption\Connector\Sabre;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\EndToEndEncryption\UserAgentManager;
+use OCA\EndToEndEncryption\E2EEnabledPathCache;
 use OCP\Files\IRootFolder;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -43,8 +44,9 @@ class PropFindPlugin extends APlugin {
 	public function __construct(IRootFolder $rootFolder,
 								IUserSession $userSession,
 								UserAgentManager $userAgentManager,
-								IRequest $request) {
-		parent::__construct($rootFolder, $userSession);
+								IRequest $request,
+								E2EEnabledPathCache $pathCache) {
+		parent::__construct($rootFolder, $userSession, $pathCache);
 		$this->userAgentManager = $userAgentManager;
 		$this->request = $request;
 	}

--- a/lib/Connector/Sabre/RedirectRequestPlugin.php
+++ b/lib/Connector/Sabre/RedirectRequestPlugin.php
@@ -31,6 +31,7 @@ use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
+use OCA\EndToEndEncryption\E2EEnabledPathCache;
 
 /**
  * Class WritePlugin

--- a/lib/Connector/Sabre/RedirectRequestPlugin.php
+++ b/lib/Connector/Sabre/RedirectRequestPlugin.php
@@ -31,7 +31,6 @@ use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
-use OCA\EndToEndEncryption\E2EEnabledPathCache;
 
 /**
  * Class WritePlugin

--- a/lib/Connector/Sabre/RedirectRequestPlugin.php
+++ b/lib/Connector/Sabre/RedirectRequestPlugin.php
@@ -92,7 +92,7 @@ class RedirectRequestPlugin extends APlugin {
 			return;
 		}
 		/** @var File|Directory $node */
-		if (!$this->isE2EEnabledPath($node->getPath())) {
+		if (!$this->isE2EEnabledPath($node)) {
 			return;
 		}
 
@@ -114,7 +114,7 @@ class RedirectRequestPlugin extends APlugin {
 			return true;
 		}
 		/** @var File|Directory $node */
-		if (!$this->isE2EEnabledPath($node->getPath())) {
+		if (!$this->isE2EEnabledPath($node)) {
 			// If this is no e2e-enabled path, return true to continue up in the event chain
 			return true;
 		}
@@ -149,7 +149,7 @@ class RedirectRequestPlugin extends APlugin {
 			return;
 		}
 		/** @var File|Directory $node */
-		if (!$this->isE2EEnabledPath($node->getPath())) {
+		if (!$this->isE2EEnabledPath($node)) {
 			return;
 		}
 
@@ -184,7 +184,7 @@ class RedirectRequestPlugin extends APlugin {
 		}
 
 		/** @var File|Directory $node */
-		if (!$this->isE2EEnabledPath($node->getPath())) {
+		if (!$this->isE2EEnabledPath($node)) {
 			return true;
 		}
 

--- a/lib/E2EEnabledPathCache.php
+++ b/lib/E2EEnabledPathCache.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2020 Georg Ehrke <georg-nextcloud@ehrke.email>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace OCA\EndToEndEncryption;
+
+use Sabre\DAV\INode;
+use OCP\Files\Node;
+use OCP\Files\IHomeStorage;
+use OCP\Files\Cache\ICache;
+use OC\Files\Storage\Wrapper\Wrapper;
+use OCA\Files_Sharing\SharedStorage;
+
+class E2EEnabledPathCache {
+	/**
+	 * @psalm-type FileId=int
+	 *
+	 * @psalm-type EncryptedState=array{0: FileId, 1: bool}
+	 *
+	 * @psalm-type Path=string
+	 *
+	 * @psalm-type StorageId=string|int
+	 */
+
+	/** @var array<StorageId, array<Path, EncryptedState>> */
+	protected $cacheEntries;
+
+	/**
+	 * Checks if the path is an E2E folder or inside an E2E folder
+	 *
+	 * @param INode&Node $node
+	 */
+	public function isE2EEnabledPath($node, string $path): bool {
+		$storage = $node->getStorage();
+		$cache = $storage->getCache();
+		$encryptedStates = $this->getEncryptedStates($cache, $path, $storage, !$storage->instanceOfStorage(IHomeStorage::class) || $storage->instanceOfStorage(SharedStorage::class));
+		foreach ($encryptedStates as [$fileid, $encryptedState]) {
+			if ($encryptedState) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Get the file ids of the given path and its parents
+	 *
+	 * @return array<Path, EncryptedState>
+	 */
+	protected function getEncryptedStates(ICache $cache, string $path, $storage, bool $isExternalStorage): array {
+		/** @psalm-suppress InvalidArgument */
+		if ($storage->instanceOfStorage(\OCA\GroupFolders\Mount\GroupFolderStorage::class)) {
+			// Special implementation for groupfolder since all groupfolders share the same storage
+			// id so add the group folder id in the cache key too.
+			$groupFolderStorage = $storage;
+			if ($this->storage instanceof Wrapper) {
+				$groupFolderStorage = $getInstanceOfStorage(\OCA\GroupFolders\Mount\GroupFolderStorage::class);
+			}
+			if ($groupFolderStorage === null) {
+				throw new \LogicException('Should not happen: Storage is instance of GroupFolderStorage but no group folder storage found while unwrapping.');
+			}
+			/**
+			 * @psalm-suppress UndefinedDocblockClass
+			 * @psalm-suppress UndefinedInterfaceMethod
+			 */
+			$cacheId = $cache->getNumericStorageId() . '/' . $groupFolderStorage->getFolderId();
+		} else {
+			$cacheId = $cache->getNumericStorageId();
+		}
+		if (isset($this->cacheEntries[$cacheId][$path])) {
+			return $this->cacheEntries[$cacheId][$path];
+		}
+
+		$parentIds = [];
+		if ($path !== $this->dirname($path)) {
+			$cacheEntries = [];
+			$cacheEntry = $cache->get($path);
+			if ($cacheEntry !== false) {
+				$cacheEntries[] = [$cacheEntry->getId(), $cacheEntry->isEncrypted()];
+				if ($cacheEntry->isEncrypted()) {
+					// no need to go further down in the tree
+					$this->cacheEntries[$cacheId][$path] = $parentEntries;
+					return $cacheEntry;
+				}
+			}
+			$cacheEntries = array_merge($this->getEncryptedStates($cache, $this->dirname($path), $storage, $isExternalStorage), $cacheEntries);
+		} elseif (!$isExternalStorage) {
+			return [];
+		}
+
+		$this->cacheEntries[$cacheId][$path] = $cacheEntries;
+		return $cacheEntries;
+	}
+
+	protected function dirname(string $path): string {
+		$dir = dirname($path);
+		return $dir === '.' ? '' : $dir;
+	}
+}

--- a/tests/Unit/Connector/Sabre/LockPluginTest.php
+++ b/tests/Unit/Connector/Sabre/LockPluginTest.php
@@ -34,6 +34,8 @@ use OCA\EndToEndEncryption\UserAgentManager;
 use OCA\EndToEndEncryption\E2EEnabledPathCache;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
+use OCP\Files\Storage\IStorage;
+use OCP\Files\IHomeStorage;
 use OCP\Files\Node;
 use OCP\IUserSession;
 use Sabre\CalDAV\ICalendar;
@@ -104,7 +106,8 @@ class LockPluginTest extends TestCase {
 				$this->rootFolder,
 				$this->userSession,
 				$this->lockManager,
-				$this->userAgentManager
+				$this->userAgentManager,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -150,7 +153,8 @@ class LockPluginTest extends TestCase {
 				$this->rootFolder,
 				$this->userSession,
 				$this->lockManager,
-				$this->userAgentManager
+				$this->userAgentManager,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -203,7 +207,8 @@ class LockPluginTest extends TestCase {
 				$this->rootFolder,
 				$this->userSession,
 				$this->lockManager,
-				$this->userAgentManager
+				$this->userAgentManager,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -289,7 +294,8 @@ class LockPluginTest extends TestCase {
 				$this->rootFolder,
 				$this->userSession,
 				$this->lockManager,
-				$this->userAgentManager
+				$this->userAgentManager,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -420,7 +426,8 @@ class LockPluginTest extends TestCase {
 				$this->rootFolder,
 				$this->userSession,
 				$this->lockManager,
-				$this->userAgentManager
+				$this->userAgentManager,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -571,7 +578,8 @@ class LockPluginTest extends TestCase {
 				$this->rootFolder,
 				$this->userSession,
 				$this->lockManager,
-				$this->userAgentManager
+				$this->userAgentManager,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -591,17 +599,33 @@ class LockPluginTest extends TestCase {
 				$this->rootFolder,
 				$this->userSession,
 				$this->lockManager,
-				$this->userAgentManager
+				$this->userAgentManager,
+				new E2EEnabledPathCache(),
 			])
 			->getMock();
+
+		$cache = $this->createMock(\OCP\Files\Storage\IStorage::class);
+		$cache->expects($this->any())
+			->method('getNumericStorageId')
+			->willReturn(42);
+
+		$storage = $this->createMock(\OCP\Files\Storage\IStorage::class);
+		$storage->expects($this->once())
+			->method('getCache')
+			->willReturn($cache);
+		$storage->expects($this->any())
+			->method('instanceOfStorage')
+			->with(IHomeStorage::class)
+			->willReturn(true);
 
 		$node = $this->createMock(Node::class);
 		$node->expects($this->once())
 			->method('isEncrypted')
 			->willReturn(true);
 		$node->expects($this->once())
-			->method('getType')
-			->willReturn(FileInfo::TYPE_FOLDER);
+			->method('getStorage')
+			->willReturn($storage);
+	  
 
 		$plugin->expects($this->once())
 			->method('getFileNode')
@@ -619,7 +643,8 @@ class LockPluginTest extends TestCase {
 				$this->rootFolder,
 				$this->userSession,
 				$this->lockManager,
-				$this->userAgentManager
+				$this->userAgentManager,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -669,7 +694,8 @@ class LockPluginTest extends TestCase {
 				$this->rootFolder,
 				$this->userSession,
 				$this->lockManager,
-				$this->userAgentManager
+				$this->userAgentManager,
+				$this->pathCache,
 			])
 			->getMock();
 

--- a/tests/Unit/Connector/Sabre/LockPluginTest.php
+++ b/tests/Unit/Connector/Sabre/LockPluginTest.php
@@ -31,6 +31,7 @@ use OCA\DAV\Upload\FutureFile;
 use OCA\EndToEndEncryption\Connector\Sabre\LockPlugin;
 use OCA\EndToEndEncryption\LockManager;
 use OCA\EndToEndEncryption\UserAgentManager;
+use OCA\EndToEndEncryption\E2EEnabledPathCache;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
@@ -56,8 +57,10 @@ class LockPluginTest extends TestCase {
 	/** @var UserAgentManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $userAgentManager;
 
-	/** @var LockPlugin */
-	private $plugin;
+	/** @var E2EEnabledPathCache|\PHPUnit\Framework\MockObject\MockObject */
+	private $pathCache;
+
+	private LockPlugin $plugin;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -66,9 +69,10 @@ class LockPluginTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->lockManager = $this->createMock(LockManager::class);
 		$this->userAgentManager = $this->createMock(UserAgentManager::class);
+		$this->pathCache = $this->createMock(E2EEnabledPathCache::class);
 
 		$this->plugin = new LockPlugin($this->rootFolder, $this->userSession,
-			$this->lockManager, $this->userAgentManager);
+			$this->lockManager, $this->userAgentManager, $this->pathCache);
 	}
 
 	public function testInitialize(): void {

--- a/tests/Unit/Connector/Sabre/PropFindPluginTest.php
+++ b/tests/Unit/Connector/Sabre/PropFindPluginTest.php
@@ -27,6 +27,7 @@ use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\EndToEndEncryption\Connector\Sabre\PropFindPlugin;
 use OCA\EndToEndEncryption\UserAgentManager;
+use OCA\EndToEndEncryption\E2EEnabledPathCache;
 use OCP\Files\IRootFolder;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -54,8 +55,7 @@ class PropFindPluginTest extends TestCase {
 	/** @var Server|\PHPUnit\Framework\MockObject\MockObject */
 	protected $server;
 
-	/** @var PropFindPlugin */
-	private $plugin;
+	private PropFindPlugin $plugin;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -65,11 +65,15 @@ class PropFindPluginTest extends TestCase {
 		$this->userAgentManager = $this->createMock(UserAgentManager::class);
 		$this->request = $this->createMock(IRequest::class);
 		$this->server = $this->createMock(Server::class);
+		$this->pathCache = $this->createMock(E2EEnabledPathCache::class);
 
-		$this->plugin = new PropFindPlugin($this->rootFolder,
+		$this->plugin = new PropFindPlugin(
+			$this->rootFolder,
 			$this->userSession,
 			$this->userAgentManager,
-			$this->request);
+			$this->request,
+			$this->pathCache
+		);
 	}
 
 	public function testInitialize(): void {

--- a/tests/Unit/Connector/Sabre/PropFindPluginTest.php
+++ b/tests/Unit/Connector/Sabre/PropFindPluginTest.php
@@ -79,13 +79,12 @@ class PropFindPluginTest extends TestCase {
 	public function testInitialize(): void {
 		$server = $this->createMock(Server::class);
 
-		$server->expects($this->at(0))
-			->method('on')
-			->with('afterMethod:PROPFIND', [$this->plugin, 'checkAccess'], 50);
-
-		$server->expects($this->at(1))
-			->method('on')
-			->with('propFind', [$this->plugin, 'updateProperty'], 105);
+		$server->expects($this->atLeast(2))
+		 ->method('on')
+		 ->withConsecutive(
+			['afterMethod:PROPFIND', [$this->plugin, 'checkAccess'], 50],
+			['propFind', [$this->plugin, 'updateProperty'], 105],
+		 );
 
 		$this->plugin->initialize($server);
 	}
@@ -125,24 +124,24 @@ class PropFindPluginTest extends TestCase {
 
 		$this->plugin->initialize($server);
 
-		$this->request->expects($this->at(0))
+		$this->request->expects($this->once())
 			->method('getHeader')
 			->with('USER_AGENT')
 			->willReturn('User-Agent-String');
 
-		$this->userAgentManager->expects($this->at(0))
+		$this->userAgentManager->expects($this->once())
 			->method('supportsEndToEndEncryption')
 			->with('User-Agent-String')
 			->willReturn($supportedUserAgent);
 
 		if (!$supportedUserAgent) {
-			$propFind->expects($this->at(0))
+			$propFind->expects($this->once())
 				->method('get')
 				->with('{http://nextcloud.org/ns}is-encrypted')
 				->willReturn($fileEncrypted ? '1' : '0');
 
 			if ($fileEncrypted) {
-				$propFind->expects($this->at(1))
+				$propFind->expects($this->once())
 					->method('set')
 					->with('{http://owncloud.org/ns}permissions', '', 200);
 			} else {

--- a/tests/Unit/Connector/Sabre/RedirectRequestPluginTest.php
+++ b/tests/Unit/Connector/Sabre/RedirectRequestPluginTest.php
@@ -91,7 +91,8 @@ class RedirectRequestPluginTest extends TestCase {
 			->setMethods(['getNode', 'isE2EEnabledPath', 'isFile'])
 			->setConstructorArgs([
 				$this->rootFolder,
-				$this->userSession
+				$this->userSession,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -141,7 +142,8 @@ class RedirectRequestPluginTest extends TestCase {
 			->setMethods(['getNode', 'isE2EEnabledPath', 'isFile'])
 			->setConstructorArgs([
 				$this->rootFolder,
-				$this->userSession
+				$this->userSession,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -190,7 +192,8 @@ class RedirectRequestPluginTest extends TestCase {
 			->setMethods(['getNode', 'isE2EEnabledPath', 'isFile'])
 			->setConstructorArgs([
 				$this->rootFolder,
-				$this->userSession
+				$this->userSession,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -223,7 +226,8 @@ class RedirectRequestPluginTest extends TestCase {
 			->setMethods(['getNode', 'isE2EEnabledPath', 'isFile'])
 			->setConstructorArgs([
 				$this->rootFolder,
-				$this->userSession
+				$this->userSession,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -263,7 +267,8 @@ class RedirectRequestPluginTest extends TestCase {
 			->setMethods(['getNode', 'isE2EEnabledPath', 'isFile'])
 			->setConstructorArgs([
 				$this->rootFolder,
-				$this->userSession
+				$this->userSession,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -308,7 +313,8 @@ class RedirectRequestPluginTest extends TestCase {
 			->setMethods(['getNode', 'isE2EEnabledPath', 'isFile'])
 			->setConstructorArgs([
 				$this->rootFolder,
-				$this->userSession
+				$this->userSession,
+				$this->pathCache,
 			])
 			->getMock();
 
@@ -341,7 +347,8 @@ class RedirectRequestPluginTest extends TestCase {
 			->setMethods(['getNode', 'isE2EEnabledPath', 'isFile'])
 			->setConstructorArgs([
 				$this->rootFolder,
-				$this->userSession
+				$this->userSession,
+				$this->pathCache,
 			])
 			->getMock();
 

--- a/tests/Unit/Connector/Sabre/RedirectRequestPluginTest.php
+++ b/tests/Unit/Connector/Sabre/RedirectRequestPluginTest.php
@@ -117,9 +117,6 @@ class RedirectRequestPluginTest extends TestCase {
 			->with('Destination', '/foo/bar/DestinationPath123.e2e-to-save');
 
 		$node = $this->createMock(File::class);
-		$node->expects($this->once())
-			->method('getPath')
-			->willReturn('/random/path/');
 
 		$plugin->expects($this->once())
 			->method('getNode')
@@ -127,7 +124,7 @@ class RedirectRequestPluginTest extends TestCase {
 			->willReturn($node);
 		$plugin->expects($this->once())
 			->method('isE2EEnabledPath')
-			->with('/random/path/')
+			->with($node)
 			->willReturn(true);
 		$plugin->expects($this->once())
 			->method('isFile')
@@ -167,9 +164,6 @@ class RedirectRequestPluginTest extends TestCase {
 			->method('setHeader');
 
 		$node = $this->createMock(File::class);
-		$node->expects($this->once())
-			->method('getPath')
-			->willReturn('/random/path/');
 
 		$plugin->expects($this->once())
 			->method('getNode')
@@ -177,7 +171,7 @@ class RedirectRequestPluginTest extends TestCase {
 			->willReturn($node);
 		$plugin->expects($this->once())
 			->method('isE2EEnabledPath')
-			->with('/random/path/')
+			->with($node)
 			->willReturn(true);
 		$plugin->expects($this->once())
 			->method('isFile')
@@ -242,9 +236,6 @@ class RedirectRequestPluginTest extends TestCase {
 			->method('setHeader');
 
 		$node = $this->createMock(File::class);
-		$node->expects($this->once())
-			->method('getPath')
-			->willReturn('/random/path/');
 
 		$plugin->expects($this->once())
 			->method('getNode')
@@ -252,7 +243,7 @@ class RedirectRequestPluginTest extends TestCase {
 			->willReturn($node);
 		$plugin->expects($this->once())
 			->method('isE2EEnabledPath')
-			->with('/random/path/')
+			->with($node)
 			->willReturn(false);
 		$plugin->expects($this->once())
 			->method('isFile')
@@ -288,9 +279,6 @@ class RedirectRequestPluginTest extends TestCase {
 			->with('http://username:password@hostname:9090/path/123/foo.e2e-to-save?arg=value#anchor');
 
 		$node = $this->createMock(File::class);
-		$node->expects($this->once())
-			->method('getPath')
-			->willReturn('/random/path/');
 
 		$plugin->expects($this->once())
 			->method('getNode')
@@ -298,7 +286,7 @@ class RedirectRequestPluginTest extends TestCase {
 			->willReturn($node);
 		$plugin->expects($this->once())
 			->method('isE2EEnabledPath')
-			->with('/random/path/')
+			->with($node)
 			->willReturn(true);
 		$plugin->expects($this->once())
 			->method('isFile')
@@ -363,9 +351,6 @@ class RedirectRequestPluginTest extends TestCase {
 			->method('setUrl');
 
 		$node = $this->createMock(File::class);
-		$node->expects($this->once())
-			->method('getPath')
-			->willReturn('/random/path/');
 
 		$plugin->expects($this->once())
 			->method('getNode')
@@ -377,7 +362,7 @@ class RedirectRequestPluginTest extends TestCase {
 			->willReturn(true);
 		$plugin->expects($this->once())
 			->method('isE2EEnabledPath')
-			->with('/random/path/')
+			->with($node)
 			->willReturn(false);
 
 		$plugin->httpMkColPut($request);

--- a/tests/Unit/Connector/Sabre/RedirectRequestPluginTest.php
+++ b/tests/Unit/Connector/Sabre/RedirectRequestPluginTest.php
@@ -25,6 +25,7 @@ namespace OCA\EndToEndEncryption\Tests\Unit\Connector\Sabre;
 
 use OCA\DAV\Connector\Sabre\File;
 use OCA\EndToEndEncryption\Connector\Sabre\RedirectRequestPlugin;
+use OCA\EndToEndEncryption\E2EEnabledPathCache;
 use OCP\Files\IRootFolder;
 use OCP\IUserSession;
 use Sabre\DAV\Server;
@@ -39,16 +40,19 @@ class RedirectRequestPluginTest extends TestCase {
 	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	private $userSession;
 
-	/** @var RedirectRequestPlugin */
-	private $plugin;
+	/** @var E2EEnabledPathCache|\PHPUnit\Framework\MockObject\MockObject */
+	private $pathCache;
+
+	private RedirectRequestPlugin $plugin;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->pathCache = $this->createMock(E2EEnabledPathCache::class);
 
-		$this->plugin = new RedirectRequestPlugin($this->rootFolder, $this->userSession);
+		$this->plugin = new RedirectRequestPlugin($this->rootFolder, $this->userSession, $this->pathCache);
 	}
 
 	public function testInitialize(): void {

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -7,9 +7,6 @@
     </UndefinedClass>
   </file>
   <file src="lib/Connector/Sabre/APlugin.php">
-    <InvalidArgument occurrences="1">
-      <code>$node</code>
-    </InvalidArgument>
     <UndefinedPropertyFetch occurrences="1">
       <code>$this-&gt;server-&gt;tree</code>
     </UndefinedPropertyFetch>
@@ -33,17 +30,5 @@
     <UndefinedPropertyFetch occurrences="1">
       <code>$this-&gt;server-&gt;tree</code>
     </UndefinedPropertyFetch>
-  </file>
-  <file src="lib/E2EEnabledPathCache.php">
-    <UndefinedClass occurrences="1">
-      <code>CappedMemoryCache</code>
-    </UndefinedClass>
-    <UndefinedDocblockClass occurrences="5">
-      <code>$this-&gt;perStorageEncryptedStateCache</code>
-      <code>$this-&gt;perStorageEncryptedStateCache</code>
-      <code>$this-&gt;perStorageEncryptedStateCache</code>
-      <code>$this-&gt;perStorageEncryptedStateCache</code>
-      <code>CappedMemoryCache</code>
-    </UndefinedDocblockClass>
   </file>
 </files>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -7,6 +7,9 @@
     </UndefinedClass>
   </file>
   <file src="lib/Connector/Sabre/APlugin.php">
+    <InvalidArgument occurrences="1">
+      <code>$node</code>
+    </InvalidArgument>
     <UndefinedPropertyFetch occurrences="1">
       <code>$this-&gt;server-&gt;tree</code>
     </UndefinedPropertyFetch>
@@ -30,5 +33,17 @@
     <UndefinedPropertyFetch occurrences="1">
       <code>$this-&gt;server-&gt;tree</code>
     </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/E2EEnabledPathCache.php">
+    <UndefinedClass occurrences="1">
+      <code>CappedMemoryCache</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass occurrences="5">
+      <code>$this-&gt;perStorageEncryptedStateCache</code>
+      <code>$this-&gt;perStorageEncryptedStateCache</code>
+      <code>$this-&gt;perStorageEncryptedStateCache</code>
+      <code>$this-&gt;perStorageEncryptedStateCache</code>
+      <code>CappedMemoryCache</code>
+    </UndefinedDocblockClass>
   </file>
 </files>

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -76,8 +76,13 @@ namespace Sabre\Dav {
 }
 
 namespace OCA\DAV\Connector\Sabre {
-    class File extends \Sabre\Dav\INode {}
-    class Directory extends \Sabre\Dav\INode {}
+    class Node extends \Sabre\Dav\INode {
+        public function getNode(): \OCP\Files\Node {
+
+        }
+    }
+    class File extends Node {}
+    class Directory extends Node {}
 }
 
 namespace OCA\DAV\Connector\Sabre\Exception {


### PR DESCRIPTION
On perftesting this changes the DB requests to determine if a path is end to encrypted from ~900 to 165 with https://github.com/nextcloud/server/pull/33602. Code is inspired by the filesystem tag checks in the workflowengine app.

Todos:

- [x] Fix unit tests
