### PR TITLE
Check node type instead of assuming

### DIFF
--- a/lib/Connector/Sabre/APlugin.php
+++ b/lib/Connector/Sabre/APlugin.php
@@ -100,8 +100,11 @@ abstract class APlugin extends ServerPlugin {
 	/**
 	 * Checks if the path is an E2E folder or inside an E2E folder
 	 */
-	protected function isE2EEnabledPath(\OCA\DAV\Connector\Sabre\Node $node): bool {
-		return $this->pathCache->isE2EEnabledPath($node->getNode());
+	protected function isE2EEnabledPath(INode $node): bool {
+		if ($node instanceof \OCA\DAV\Connector\Sabre\Node) {
+			return $this->pathCache->isE2EEnabledPath($node->getNode());
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Because some Webdav endpoints use different node types and might fall into this logic.

**Haven't tested this**.

Reported by @artonge  while testing the album feature and we found this error:
```
<s:message>Argument 1 passed to OCA\EndToEndEncryption\Connector\Sabre\APlugin::isE2EEnabledPath() must be an instance of OCA\DAV\Connector\Sabre\Node, instance of OCA\Photos\Sabre\Album\AlbumRoot given, called in /var/www/tech-preview.nextcloud.com/apps/end_to_end_encryption/lib/Connector/Sabre/LockPlugin.php on line 106</s:message>
```