### PR TITLE
fix: remove lock without mountpoint

### DIFF
--- a/lib/RollbackService.php
+++ b/lib/RollbackService.php
@@ -79,6 +79,7 @@ class RollbackService {
 		foreach ($locks as $lock) {
 			$mountPoints = $this->userMountCache->getMountsForFileId($lock->getId());
 			if (empty($mountPoints)) {
+				$this->lockMapper->delete($lock);
 				continue;
 			}
 

--- a/tests/Unit/RollbackServiceTest.php
+++ b/tests/Unit/RollbackServiceTest.php
@@ -185,9 +185,9 @@ class RollbackServiceTest extends TestCase {
 				null
 			);
 
-		$this->lockMapper->expects($this->once())
+		$this->lockMapper->expects($this->exactly(2))
 			->method('delete')
-			->with($locks[5]);
+			->withConsecutive([$locks[0]], [$locks[5]]);
 
 		$this->logger->expects($this->exactly(3))
 			->method('critical');


### PR DESCRIPTION
Fix #399

A folder is locked to keep file and metadata in sync[^1].

`oc_e2e_encryption_lock.id` is related to `oc_filecache.fileid`.

Is the filecache entry gone, the lock entry is in an undefined state. It's not possible to release the lock due to the missing reference, and the lock will stay forever.

[^1]: https://github.com/nextcloud/end_to_end_encryption_rfc/blob/master/RFC.md#update-metadata-file