### PR TITLE
[backport25] Root lock blocker

### DIFF
--- a/lib/Controller/LockingController.php
+++ b/lib/Controller/LockingController.php
@@ -90,6 +90,12 @@ class LockingController extends OCSController {
 			throw new OCSForbiddenException($this->l10n->t('You are not allowed to create the lock'));
 		}
 
+		if ($userFolder->getId() === $id) {
+			$e = new OCSForbiddenException($this->l10n->t('You are not allowed to lock the root'));
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			throw $e;
+		}
+
 		$nodes = $userFolder->getById($id);
 		if (!isset($nodes[0]) || !$nodes[0] instanceof Folder) {
 			throw new OCSForbiddenException($this->l10n->t('You are not allowed to create the lock'));


### PR DESCRIPTION
When being in trouble with locked root folders, Nextcloud implemented a blocker for root locks.
The blocker is included in upstream with stable26, but lacking in stable25.

Thus, added for V25 as backport.