### PR TITLE
Fix check also for metadata version 1

### DIFF
--- a/lib/MetaDataStorage.php
+++ b/lib/MetaDataStorage.php
@@ -249,6 +249,10 @@ class MetaDataStorage implements IMetaDataStorage {
 				return "";
 			}
 
+			if ($decodedMetadata['metadata']['version'] === 1) {
+				return "";
+			}
+
 			throw $ex;
 		}
 	}


### PR DESCRIPTION
It seems that metadata version could also be 1 :see_no_evil: 

This MR now uses exactly the same checks as in 
https://github.com/nextcloud/end_to_end_encryption/blob/1a2e6031dc66560d444f12da1c3309fcd85748ea/lib/Middleware/ClientHasCapabilityMiddleware.php#L70-L80

Relates #578 #609
