### PR TITLE
add a new API to allow user to upload an existing certificate

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -30,6 +30,7 @@ return [
 		['name' => 'Key#setPrivateKey', 'url' => '/api/v{apiVersion}/private-key', 'verb' => 'POST', 'requirements' => ['apiVersion' => '[1-2]']],
 		['name' => 'Key#getPrivateKey', 'url' => '/api/v{apiVersion}/private-key', 'verb' => 'GET', 'requirements' => ['apiVersion' => '[1-2]']],
 		['name' => 'Key#deletePrivateKey', 'url' => '/api/v{apiVersion}/private-key', 'verb' => 'DELETE', 'requirements' => ['apiVersion' => '[1-2]']],
+		['name' => 'Key#setPublicKey', 'url' => '/api/v{apiVersion}/public-key', 'verb' => 'PUT', 'requirements' => ['apiVersion' => '[1-2]']],
 		['name' => 'Key#createPublicKey', 'url' => '/api/v{apiVersion}/public-key', 'verb' => 'POST', 'requirements' => ['apiVersion' => '[1-2]']],
 		['name' => 'Key#getPublicKeys', 'url' => '/api/v{apiVersion}/public-key', 'verb' => 'GET', 'requirements' => ['apiVersion' => '[1-2]']],
 		['name' => 'Key#deletePublicKey', 'url' => '/api/v{apiVersion}/public-key', 'verb' => 'DELETE', 'requirements' => ['apiVersion' => '[1-2]']],

--- a/lib/Controller/KeyController.php
+++ b/lib/Controller/KeyController.php
@@ -206,6 +206,26 @@ class KeyController extends OCSController {
 	}
 
 	/**
+	 * Set public key
+	 *
+	 * @NoAdminRequired
+	 * @E2ERestrictUserAgent
+	 * @throws OCSBadRequestException
+	 */
+	public function setPublicKey(string $publicKey): DataResponse {
+		try {
+			$this->keyStorage->setPublicKey($publicKey, $this->userId);
+		} catch (KeyExistsException $e) {
+			return new DataResponse([], Http::STATUS_CONFLICT);
+		} catch (Exception $e) {
+			$this->logger->error("Fail to set user public key", ['exception' => $e, 'app' => $this->appName]);
+			throw new OCSBadRequestException($this->l10n->t('Internal error'));
+		}
+
+		return new DataResponse(['public-key' => $publicKey]);
+	}
+
+	/**
 	 * Delete the users public key
 	 *
 	 * @NoAdminRequired


### PR DESCRIPTION
is needed to be able to setup sharing when an user has an existing certificate that may have been created outside of Nextcloud end-to-end encryption app

that would for example apply when an external certificate authority is in use to deliver user certificates for end-to-end encryption