### PR TITLE
feat: Own the handling of the is-encrypted DAV property

### DIFF
--- a/tests/Unit/Connector/Sabre/PropFindPluginTest.php
+++ b/tests/Unit/Connector/Sabre/PropFindPluginTest.php
@@ -86,6 +86,7 @@ class PropFindPluginTest extends TestCase {
 			->method('on')
 			->withConsecutive(
 				['afterMethod:PROPFIND', [$this->plugin, 'checkAccess'], 50],
+				['propFind', [$this->plugin, 'setEncryptedProperty'], 104],
 				['propFind', [$this->plugin, 'updateProperty'], 105],
 			);
 

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -65,6 +65,7 @@ namespace Sabre\DAV {
         public function set(string $key, string $value, int $stuff) {}
         public function getPath(): string {}
         public function setPath(string $string): void {}
+	    public function handle($propertyName, $valueOrCallBack)
     }
 
     class Server {


### PR DESCRIPTION
The is-encrypted property is signaling the E2EE status, not the SSE one. So it does not make sense to keep it in the server repo.

- Server counterpart: https://github.com/nextcloud/server/pull/47495