### PR TITLE
chore: Prepare v1.15.3

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@ Provides the necessary endpoint to enable end-to-end encryption.
 
 **Notice:** E2EE is currently not compatible to be used together with server-side encryption
 	]]></description>
-	<version>1.15.2</version>
+	<version>1.15.3</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<namespace>EndToEndEncryption</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "end_to_end_encryption",
-  "version": "1.15.0",
+  "version": "1.15.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "end_to_end_encryption",
-      "version": "1.15.0",
+      "version": "1.15.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "end_to_end_encryption",
-  "version": "1.15.0",
+  "version": "1.15.3",
   "description": "Provides the necessary endpoint to enable End-to-End encryption.",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What's Changed

## Fixes

* fix: Upload to the correct path by @artonge in https://github.com/nextcloud/end_to_end_encryption/pull/751

### Dependencies

* Fix npm audit by @nextcloud-command in https://github.com/nextcloud/end_to_end_encryption/pull/1004
* Update nextcloud/ocp dependency by @nextcloud-command in https://github.com/nextcloud/end_to_end_encryption/pull/1023
* chore: Update workflows by @artonge in https://github.com/nextcloud/end_to_end_encryption/pull/959
* Chore(deps-dev): Bump @vue/test-utils from 1.3.0 to 1.3.6 by @dependabot in https://github.com/nextcloud/end_to_end_encryption/pull/679
* Chore(deps): Bump @nextcloud/router from 2.2.0 to 2.2.1 by @dependabot in https://github.com/nextcloud/end_to_end_encryption/pull/689
* Chore(deps): Bump @peculiar/x509 from 1.9.2 to 1.9.7 by @dependabot in https://github.com/nextcloud/end_to_end_encryption/pull/682
* Chore(deps): Bump @nextcloud/vue from 7.6.0 to 7.6.1 by @dependabot in https://github.com/nextcloud/end_to_end_encryption/pull/685

# Chores

* chore(CI): Adjust testing matrix for Nextcloud 29 on stable29 by @nickvergessen in https://github.com/nextcloud/end_to_end_encryption/pull/618

**Full Changelog**: https://github.com/nextcloud/end_to_end_encryption/compare/v1.15.2...v1.15.3