### PR TITLE
docs: add changelog to inform admins about changes within app store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,26 @@
 <!--
-  - SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-## Release 1.11.0-beta.1
 
-- Compatibility with NC 25
-- Large performance improvement in the dav plugins
-- Allow user to delete their own keys from the settings
-- Allow admin to limit who (list of groups) can use the app
-- Make user agents allowed to interact with e2ee configurable by admin
-- Updated translations
+# Changelog
+
+<!-- All notable changes to this project will be documented in this file so they will be shown in the Nextcloud app store "changes"-section -->
+
+## v1.18.0 - 2025-10-14
+### Added
+* Added support for Nextcloud 32
+* Add OpenAPI support
+* feat: add documentation about fetching metadata through WebDAV
+* feat: optimize keys root folder fetching
+
+### Fixed
+* fix: support sha-1 algo for user certificate signature
+* fix(docs): slightly improve docs on initializing an encrypted folder
+* fix(docs): adjust text because e2ee is now possible in browser
+* fix(docs): typos
+
+### Changed
+* Updated translations
+* Bump cipher-base to 1.0.6
+* Updated development dependencies


### PR DESCRIPTION
* resolves #651 

This allows admins to see what changed in an update directly within Nextcloud app store.
Yes it adds a small amount of more work during a release, but it should be ok for the sake of more transparent releases and better UX for admins.