### PR TITLE
fix(browser): ensure created e2ee folder is not pending

### DIFF
--- a/src/components/CreateFolderDialog/CreateFolderDialogStepFolderName.vue
+++ b/src/components/CreateFolderDialog/CreateFolderDialogStepFolderName.vue
@@ -7,7 +7,8 @@
 import type { IFolder, INode, InvalidFilenameError } from '@nextcloud/files'
 
 import { getCurrentUser } from '@nextcloud/auth'
-import { Folder, InvalidFilenameErrorReason, validateFilename } from '@nextcloud/files'
+import { Folder, InvalidFilenameErrorReason, Permission, validateFilename } from '@nextcloud/files'
+import { defaultRootPath } from '@nextcloud/files/dav'
 import { t } from '@nextcloud/l10n'
 import { computed, inject, onMounted, ref, watch } from 'vue'
 import NcInputField from '@nextcloud/vue/components/NcInputField'
@@ -83,8 +84,13 @@ async function createFolder(): Promise<true | void> {
 		id: folderId,
 		owner: getCurrentUser()!.uid,
 		source: props.context.source + '/' + folderName.value.trim(),
+		root: defaultRootPath,
+		crtime: new Date(),
+		mtime: new Date(),
+		permissions: Permission.READ, // TODO: allow more permissions once we support that
+		size: 0, // its empty for now
 		attributes: {
-			'is-encrypted': 1,
+			'e2ee-is-encrypted': 1,
 		},
 	})
 	emit('folderCreated', folder)

--- a/tests/playwright/e2e/setup-e2ee.spec.ts
+++ b/tests/playwright/e2e/setup-e2ee.spec.ts
@@ -78,6 +78,10 @@ test.describe('with enabled browser e2ee', () => {
 		// see the dialog is closed
 		await expect(dialog.dialogLocator).toHaveCount(0)
 		// the folder was created
-		await expect(filesApp.getFileOrFolder('test-folder')).toBeVisible()
+		const row = filesApp.getFileOrFolder('test-folder')
+		await expect(row).toBeVisible()
+		// see its not pending (in that case a size is shown) and has modification time
+		await expect(row.getByRole('cell', { name: /0 kb/i })).toBeVisible()
+		await expect(row.getByRole('cell', { name: /few seconds ago/i })).toBeVisible()
 	})
 })


### PR DESCRIPTION
When emitting the new folder to the files app we need to pass all attributes of the folder - otherwise its marked as "pending".

Also fixed a typo, as the prop is called "e2e-is-encrypted" not "is-encrypted".