### PR TITLE
refactor: add RSA utils to ensure keys have the right usage

### DIFF
--- a/src/services/Metadata.ts
+++ b/src/services/Metadata.ts
@@ -12,7 +12,7 @@ import { base64ToBuffer, bufferToBase64, bufferToString, stringToBuffer } from '
 import { compress, uncompress } from './compression.ts'
 import { encryptWithAES, sha256Hash } from './crypto.ts'
 import logger from './logger.ts'
-import { convertEncryptionKeyToSigningKey } from './privateKeyUtils.ts'
+import { ensureKeyUsage } from './rsaUtils.ts'
 
 interface IRawMetadataUser {
 	/**
@@ -231,7 +231,7 @@ export class Metadata {
 			})],
 		})
 
-		const signKey = await convertEncryptionKeyToSigningKey(certificate.privateKey!)
+		const signKey = await ensureKeyUsage(certificate.privateKey!, 'sign')
 
 		await cms.sign(signKey, 0, 'SHA-256', metadataForSignature)
 

--- a/src/services/privateKeyUtils.ts
+++ b/src/services/privateKeyUtils.ts
@@ -95,29 +95,6 @@ export async function decryptPrivateKey(privateKeyInfo: PrivateKeyInfo, mnemonic
 }
 
 /**
- * Hack to allow signing the CSR with the RSA key we created for encryption
- * (reason is that its not recommended for RSA to use the same key for both signing and encryption)
- *
- * @param encryptionKey - The key generated with encryption usage
- */
-export async function convertEncryptionKeyToSigningKey(encryptionKey: CryptoKey): Promise<CryptoKey> {
-	const signKeyJwk = {
-		...await self.crypto.subtle.exportKey('jwk', encryptionKey),
-		alg: 'RS256',
-		key_ops: ['sign'],
-		kty: 'RSA',
-	}
-
-	return await self.crypto.subtle.importKey(
-		'jwk',
-		signKeyJwk,
-		{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
-		true,
-		['sign'],
-	)
-}
-
-/**
  * Derives a private key from the given mnemonic using PBKDF2.
  *
  * @param mnemonic - The user's mnemonic

--- a/src/services/rsaUtils.spec.ts
+++ b/src/services/rsaUtils.spec.ts
@@ -1,0 +1,83 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { ensureKeyUsage } from './rsaUtils.ts'
+
+const encryptionKeys = await globalThis.crypto.subtle.generateKey(
+	{
+		name: 'RSA-OAEP',
+		modulusLength: 2048,
+		publicExponent: new Uint8Array([1, 0, 1]),
+		hash: 'SHA-256',
+	},
+	true,
+	['encrypt', 'decrypt'],
+)
+
+const signingKeys = await globalThis.crypto.subtle.generateKey(
+	{
+		name: 'RSASSA-PKCS1-v1_5',
+		modulusLength: 2048,
+		publicExponent: new Uint8Array([1, 0, 1]),
+		hash: 'SHA-256',
+	},
+	true,
+	['sign', 'verify'],
+)
+
+describe('ensureKeyUsage', () => {
+	it('should return the same key if it already has the intended usage', async () => {
+		const spy = vi.spyOn(globalThis.crypto.subtle, 'exportKey')
+		const key = await ensureKeyUsage(encryptionKeys.publicKey, 'encrypt')
+		expect(key).toBe(encryptionKeys.publicKey)
+		expect(spy).not.toHaveBeenCalled()
+	})
+
+	it.for`
+	                         key |        usage
+	-----------------------------|-------------
+	${encryptionKeys.publicKey}  | ${'decrypt'}
+	${encryptionKeys.publicKey}  | ${'sign'}
+	${encryptionKeys.privateKey} | ${'encrypt'}
+	${encryptionKeys.privateKey} | ${'verify'}
+	${signingKeys.publicKey}     | ${'sign'}
+	${signingKeys.publicKey}     | ${'decrypt'}
+	${signingKeys.privateKey}    | ${'verify'}
+	${signingKeys.privateKey}    | ${'encrypt'}
+	`('cannot convert public to private key', async ({ key, usage }) => {
+		const spy = vi.spyOn(globalThis.crypto.subtle, 'exportKey')
+		await expect(ensureKeyUsage(key, usage)).rejects.toThrow('Cannot convert private key to public key and vice versa')
+		expect(spy).not.toHaveBeenCalled()
+	})
+
+	it('can sign with an encryption key', async () => {
+		const signingKey = await ensureKeyUsage(encryptionKeys.privateKey, 'sign')
+		expect(signingKey.usages).toContain('sign')
+
+		const data = new TextEncoder().encode('Hello, World!')
+		await expect(globalThis.crypto.subtle.sign(
+			{
+				name: 'RSASSA-PKCS1-v1_5',
+			},
+			signingKey,
+			data,
+		)).resolves.not.toThrow()
+	})
+
+	it('can encrypt with signing key', async () => {
+		const signingKey = await ensureKeyUsage(signingKeys.publicKey, 'encrypt')
+		expect(signingKey.usages).toContain('encrypt')
+
+		const data = new TextEncoder().encode('Hello, World!')
+		await expect(globalThis.crypto.subtle.encrypt(
+			{
+				name: 'RSA-OAEP',
+			},
+			signingKey,
+			data,
+		)).resolves.not.toThrow()
+	})
+})

--- a/src/services/rsaUtils.ts
+++ b/src/services/rsaUtils.ts
@@ -1,0 +1,49 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Hack to allow signing and encryption with one RSA key
+ * (reason is that its not recommended for RSA to use the same key for both signing and encryption)
+ *
+ * @param key - The key
+ * @param usage - The intended usage of the key
+ */
+export async function ensureKeyUsage(key: CryptoKey, usage: 'decrypt' | 'encrypt' | 'sign' | 'verify'): Promise<CryptoKey> {
+	// check if already has the intended usage
+	if (key.usages.includes(usage)) {
+		return key
+	}
+
+	// we can only convert between private and public keys
+	if ((usage === 'sign' && !key.usages.includes('decrypt'))
+		|| (usage === 'verify' && !key.usages.includes('encrypt'))
+		|| (usage === 'encrypt' && !key.usages.includes('verify'))
+		|| (usage === 'decrypt' && !key.usages.includes('sign'))
+	) {
+		throw new Error('Cannot convert private key to public key and vice versa')
+	}
+
+	// export the key to JWK and adjust the key_ops
+	const jwk = await globalThis.crypto.subtle.exportKey('jwk', key)
+	jwk.key_ops = [usage]
+	let name: string
+	// adjust the algorithm
+	if (usage === 'sign' || usage === 'verify') {
+		name = 'RSASSA-PKCS1-v1_5'
+		jwk.alg = 'RS256'
+	} else {
+		name = 'RSA-OAEP'
+		jwk.alg = 'RSA-OAEP-256'
+	}
+
+	// import the key again with the new usage
+	return await globalThis.crypto.subtle.importKey(
+		'jwk',
+		jwk,
+		{ name, hash: 'SHA-256' },
+		true,
+		[usage],
+	)
+}


### PR DESCRIPTION
This is needed as on webcrypto RSA keys have either signing or encryption usage but never both. So we need to convert them for both usages.

This makes it a bit better testable (also includes tests) and will be reused a lot in follow ups.