### PR TITLE
chore: prepare v2.0.0-dev.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,27 @@
 
 <!-- All notable changes to this project will be documented in this file so they will be shown in the Nextcloud app store "changes"-section -->
 
-## v2.0.0-dev.1 - 2025-11-20
+## v2.0.0-dev.2 - 2025-12-05
 ### Added
 * Setup end-to-end encryption in the web interface.
-  It is now possible to setup end-to-end encryption in the web interface (within the files app),
-  and to also create new encrypted folders.
-  **Please note: It is not yet possible to create sub-folders and to write or move encrypted files**.
+  When end-to-end encryption is enabled in the browser (see personal settings - security),
+  users can setup the end-to-end encryption within the files app.
+  For this a new entry in the "+ New" menu was added ("Create new encrypted folder").
+* Browser based end-to-end encryption (when enabled in personal security settings):
+  * Users can now create subfolder within encrypted folders directly in the files app.
+
+### Fixed
+<!-- TODO: Remove this section for the final release -->
+Those fixes only affect you if you already used a previous pre-release of v2.
+* Do not allow creating nested e2ee root folders.
+* Ensure created e2ee folder is not pending in the files app.
+* Folders also need the `is-encrypted` attribute to be correctly displayed in the files app.
 
 ### Changed
-* Updated translations
 * Updated dependencies
+* Updated translations
 * The frontend is now using Vue 3
+* The frontend is now tested with end-to-end integration tests (Playwright)
 
 ## v1.18.0 - 2025-10-14
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 This app provides all the necessary APIs to implement End-to-End encryption on the client side.
 Additionally it implements Secure FileDrop and makes sure that End-to-End encrypted files are neither accessible via the web interface nor other WebDAV clients.
 	]]></description>
-	<version>2.0.0-dev.1</version>
+	<version>2.0.0-dev.2</version>
 	<licence>agpl</licence>
 	<author>Nextcloud GmbH</author>
 	<namespace>EndToEndEncryption</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "end_to_end_encryption",
-  "version": "2.0.0-dev.1",
+  "version": "2.0.0-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "end_to_end_encryption",
-      "version": "2.0.0-dev.1",
+      "version": "2.0.0-dev.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "end_to_end_encryption",
-  "version": "2.0.0-dev.1",
+  "version": "2.0.0-dev.2",
   "private": true,
   "description": "Provides the necessary endpoint to enable End-to-End encryption.",
   "homepage": "https://github.com/nextcloud/end_to_end_encryption#readme",


### PR DESCRIPTION
## v2.0.0-dev.2 - 2025-12-05
### Added
* Setup end-to-end encryption in the web interface.
  When end-to-end encryption is enabled in the browser (see personal settings - security),
  users can setup the end-to-end encryption within the files app.
  For this a new entry in the "+ New" menu was added ("Create new encrypted folder").
* Browser based end-to-end encryption (when enabled in personal security settings):
  * Users can now create subfolder within encrypted folders directly in the files app.

### Fixed
<!-- TODO: Remove this section for the final release -->
Those fixes only affect you if you already used a previous pre-release of v2.
* Do not allow creating nested e2ee root folders.
* Ensure created e2ee folder is not pending in the files app.
* Folders also need the `is-encrypted` attribute to be correctly displayed in the files app.

### Changed
* Updated dependencies
* Updated translations
* The frontend is now using Vue 3
* The frontend is now tested with end-to-end integration tests (Playwright)