### PR TITLE
fix: properly handle deleted sub-folders

### DIFF
--- a/lib/Controller/V1/LockingController.php
+++ b/lib/Controller/V1/LockingController.php
@@ -136,7 +136,7 @@ class LockingController extends OCSController {
 			throw new OCSForbiddenException($this->l10n->t('You are not allowed to remove the lock'));
 		}
 
-		$hadChanges = $this->fileService->finalizeChanges($nodes[0]);
+		$hadChanges = $this->fileService->finalizeChanges($nodes[0]) !== false;
 
 		try {
 			$this->metaDataStorage->saveIntermediateFile($ownerId, $id);

--- a/lib/IMetaDataStorage.php
+++ b/lib/IMetaDataStorage.php
@@ -48,11 +48,12 @@ interface IMetaDataStorage {
 	/**
 	 * Moves intermediate metadata file to final file
 	 *
+	 * @param bool $deleted - Whether the file was deleted
 	 * @throws NotPermittedException
 	 * @throws NotFoundException
 	 * @throws MissingMetaDataException
 	 */
-	public function saveIntermediateFile(string $userId, int $id): void;
+	public function saveIntermediateFile(string $userId, int $id, bool $deleted = false): void;
 
 	/**
 	 * Get the stored signature

--- a/lib/MetaDataStorage.php
+++ b/lib/MetaDataStorage.php
@@ -160,9 +160,12 @@ class MetaDataStorage implements IMetaDataStorage {
 	/**
 	 * @inheritDoc
 	 */
-	public function saveIntermediateFile(string $userId, int $id): void {
+	public function saveIntermediateFile(string $userId, int $id, bool $deleted = false): void {
 		$this->verifyFolderStructure();
-		$this->verifyOwner($userId, $id);
+		if (!$deleted) {
+			// if the file was deleted the owner check cannot work
+			$this->verifyOwner($userId, $id);
+		}
 
 		$folderName = $this->getFolderNameForFileId($id);
 		try {
@@ -282,8 +285,8 @@ class MetaDataStorage implements IMetaDataStorage {
 			throw new NotFoundException('No user-root for ' . $userId);
 		}
 
-		$ownerNodes = $userFolder->getById($id);
-		if (!isset($ownerNodes[0])) {
+		$node = $userFolder->getFirstNodeById($id);
+		if ($node === null) {
 			throw new NotFoundException('No file for owner with ID ' . $id);
 		}
 	}

--- a/tests/Unit/Controller/MetaDataControllerTest.php
+++ b/tests/Unit/Controller/MetaDataControllerTest.php
@@ -23,42 +23,22 @@ use OCP\Files\NotPermittedException;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\Share\IManager as ShareManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class MetaDataControllerTest extends TestCase {
 
-
-	/** @var string */
-	private $appName;
-
-	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
-	private $request;
-
-	/** @var string */
-	private $userId;
-
-	/** @var IMetaDataStorage|\PHPUnit\Framework\MockObject\MockObject */
-	private $metaDataStorage;
-
-	/** @var LockManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $lockManager;
-
-	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
-	private $logger;
-
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	private $l10n;
-
-	/** @var ShareManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $shareManager;
-
-	/** @var MetaDataController */
-	private $controller;
-
-	/** @var IRootFolder */
-	private $rootFolder;
-
+	private string $appName;
+	private IRequest&MockObject $request;
+	private string $userId;
+	private IMetaDataStorage&MockObject $metaDataStorage;
+	private LockManager&MockObject $lockManager;
+	private LoggerInterface&MockObject $logger;
+	private IL10N&MockObject $l10n;
+	private ShareManager&MockObject $shareManager;
+	private MetaDataController $controller;
+	private IRootFolder&MockObject $rootFolder;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/Unit/FileServiceTest.php
+++ b/tests/Unit/FileServiceTest.php
@@ -105,7 +105,7 @@ class FileServiceTest extends TestCase {
 		$file4->expects($this->once())->method('delete');
 
 		$actual = $this->fileService->finalizeChanges($folder);
-		$this->assertTrue($actual);
+		$this->assertEquals([4], $actual); // file 4 is deleted
 	}
 
 	private function getSampleFolderForEmpty(): array {
@@ -147,18 +147,22 @@ class FileServiceTest extends TestCase {
 		$file1 = $this->createMock(Node::class);
 		$file1->method('getName')->willReturn('7215ee9c7d9dc229d2921a40e899ec5f.e2e-to-save');
 		$file1->method('getPath')->willReturn('/foo/bar/7215ee9c7d9dc229d2921a40e899ec5f.e2e-to-save');
+		$file1->method('getId')->willReturn(1);
 
 		$file2 = $this->createMock(Node::class);
 		$file2->method('getName')->willReturn('23b58def11b45727d3351702515f86af.e2e-to-save');
 		$file2->method('getPath')->willReturn('/foo/bar/23b58def11b45727d3351702515f86af.e2e-to-save');
+		$file2->method('getId')->willReturn(2);
 
 		$file3 = $this->createMock(Node::class);
 		$file3->method('getName')->willReturn('1545e945d5c3e7d9fa642d0a57fc8432');
+		$file3->method('getId')->willReturn(3);
 
 		$file4 = $this->createMock(Node::class);
 		$file4->method('getName')->willReturn('a9473ded85aa51851deb4859cdd53f98.e2e-to-delete');
 		$file4->method('getPath')->willReturn('/foo/bar/a9473ded85aa51851deb4859cdd53f98.e2e-to-delete');
 		$file4->method('getStorage')->willReturn($storage);
+		$file4->method('getId')->willReturn(4);
 
 		$folder = $this->createMock(Folder::class);
 		$folder->method('getDirectoryListing')->willReturn([
@@ -168,6 +172,7 @@ class FileServiceTest extends TestCase {
 			$file4,
 		]);
 		$folder->method('getName')->willReturn('root');
+		$folder->method('getId')->willReturn(99);
 
 		return [
 			$folder,

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.10.3@90b5b9f5e7c8e441b191d3c82c58214753d7c7c1">
+<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
   <file src="lib/Connector/Sabre/APlugin.php">
     <UndefinedPropertyFetch>
       <code><![CDATA[$this->server->tree]]></code>
@@ -18,5 +18,10 @@
     <UndefinedPropertyFetch>
       <code><![CDATA[$this->server->tree]]></code>
     </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/FileService.php">
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[unshareStorage]]></code>
+    </UndefinedInterfaceMethod>
   </file>
 </files>


### PR DESCRIPTION
If a folder is deleted then the intermediate file cannot be written because the owner check fails (the file just does not exist anymore). So to fix the situation (unlocking a folder if a sub-folder is deleted):
1. Handle touched folders by deepest path first
2. Keep track of deleted nodes and ignore the owner check for writing intermediate files.