### PR TITLE
fix: do not inline chunks into entry points

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,4 +18,12 @@ export default createAppConfig({
 	extractLicenseInformation: {
 		includeSourceMaps: true,
 	},
+	config: {
+		build: {
+			rollupOptions: {
+				// TODO: Remove when merged https://github.com/nextcloud/server/pull/56941
+				preserveEntrySignatures: 'strict',
+			},
+		},
+	},
 })


### PR DESCRIPTION
Vite will try to minimize the number of chunks to increase performance, but this will inline chunks in the entry point and thus adding exports that can be imported by other modules causing the entry point to be re-evaluated.
So we need to disabled this until fixed in server:
- ref: https://github.com/nextcloud/server/pull/56941