### PR TITLE
fix: ensure warning is not shown if `do-not-show-again` is selected

### DIFF
--- a/src/components/BrowserWarning.vue
+++ b/src/components/BrowserWarning.vue
@@ -5,7 +5,7 @@
 
 <script setup lang="ts">
 import { t } from '@nextcloud/l10n'
-import { ref, watchEffect } from 'vue'
+import { onMounted, ref, watchEffect } from 'vue'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import { storage, StorageKeys } from '../services/storage.ts'
@@ -19,7 +19,8 @@ defineProps<{
 	heading: string
 }>()
 
-const dontShowAgain = ref(storage.getItem(StorageKeys.SuppressBrowserWarning) === 'true')
+const dontShowAgainStored = storage.getItem(StorageKeys.SuppressBrowserWarning) === 'true'
+const dontShowAgain = ref(dontShowAgainStored)
 watchEffect(() => {
 	if (dontShowAgain.value) {
 		confirmToggle.value = true
@@ -29,10 +30,16 @@ watchEffect(() => {
 	}
 })
 
+onMounted(() => {
+	if (dontShowAgainStored) {
+		confirmToggle.value = true
+	}
+})
 </script>
 
 <template>
 	<NcNoteCard
+		v-if="!dontShowAgainStored"
 		:heading
 		show-alert
 		type="warning">

--- a/src/components/MnemonicPromptDialog.vue
+++ b/src/components/MnemonicPromptDialog.vue
@@ -14,7 +14,6 @@ const emit = defineEmits<{
 	(e: 'close', mnemonic: string): void
 }>()
 
-const dialogRef = ref()
 const mnemonic = ref('')
 const confirmToggle = ref(false)
 
@@ -41,7 +40,6 @@ const buttons = computed(() => [
 
 <template>
 	<NcDialog
-		ref="dialogRef"
 		:name="t('end_to_end_encryption', 'Enter your 12 words mnemonic')"
 		:buttons="buttons"
 		:is-form="true"


### PR DESCRIPTION
For security reasons the state is saved in browser storage thus is will be shown again if you logout and login again, but its not shown on page reload.