### PR TITLE
fix(sharing): adjusted information about sharing

### DIFF
--- a/src/components/FilesSharingSidebarSection/FilesSharingSidebarSectionUsers.vue
+++ b/src/components/FilesSharingSidebarSection/FilesSharingSidebarSectionUsers.vue
@@ -236,7 +236,10 @@ function getSharePermissions(share: IShare): Permission {
 		<h5 :class="$style.sidebarSection__heading">
 			{{ t('end_to_end_encryption', 'End-to-end encrypted shares') }}
 		</h5>
-		<p>{{ t('end_to_end_encryption', 'Users always have access to the full encrypted folder.') }}</p>
+		<p>
+			{{ t('end_to_end_encryption', 'Share recipients always have access to the full encrypted folder.') }}
+			{{ t('end_to_end_encryption', 'It is only possible to share with accounts that have already setup end-to-end encryption.') }}
+		</p>
 		<NcSelectUsers
 			:class="$style.sidebarSection__selectUsers"
 			:disabled="isCreatingShare"


### PR DESCRIPTION
1. use `account` to not use `user` which we try to not use for translations.
2. add information that users without e2ee will not be listed for sharing.