### PR TITLE
fix: ensure new files and folders will be created with unique names

### DIFF
--- a/src/models/Metadata.ts
+++ b/src/models/Metadata.ts
@@ -121,6 +121,16 @@ export class Metadata<MetaData extends IRawMetadata = IRawMetadata> {
 		}
 	}
 
+	/**
+	 * Get the list of all contents (files and folders) in the metadata.
+	 */
+	listContents(): string[] {
+		return [
+			...Object.values(this._metadata.folders),
+			...Object.values(this._metadata.files).map((file) => file.filename),
+		]
+	}
+
 	public getFolder(uuid: string): string | undefined {
 		return this._metadata.folders[uuid]
 	}


### PR DESCRIPTION
- resolves https://github.com/nextcloud/end_to_end_encryption/issues/1287

Also restructured the PUT interceptor as it was confusing in the first version (see review back then).