### PR TITLE
chore: prepare v2.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 <!-- All notable changes to this project will be documented in this file so they will be shown in the Nextcloud app store "changes"-section -->
 
-## v2.0.0-rc.3 - 2025-12-15
+## v2.0.0-rc.4 - 2025-12-18
 ### Added
 * Setup end-to-end encryption in the web interface.
   When end-to-end encryption is enabled in the browser (see personal settings - security),
@@ -25,6 +25,7 @@
   * Sharing encrypted root folders is now possible from within the files app.
     Using the files sidebar just like with regular files,
     though shares always have all permissions enabled as per requirements of end-to-end encryption.
+  * Allow to create read only shares with users.
 
 ### Fixed
 * Fixed locking to allow leaving encrypted root folders properly.
@@ -36,6 +37,10 @@ Those fixes only affect you if you already used a previous pre-release of v2.
 * Folders also need the `is-encrypted` attribute to be correctly displayed in the files app.
 * Sharing sidebar work now also when `debug` mode is disabled.
 * "Do not ask again" toggle of mnemonic dialog is respected.
+* fix(sharing): consolidate share tab and ensure user keys are used
+* fix(sharing): hide native sharing sections
+* fix(sharing): adjusted information about sharing
+* fix: ensure new files and folders will be created with unique names
 
 ### Changed
 * Updated dependencies

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 This app provides all the necessary APIs to implement End-to-End encryption on the client side.
 Additionally it implements Secure FileDrop and makes sure that End-to-End encrypted files are neither accessible via the web interface nor other WebDAV clients.
 	]]></description>
-	<version>2.0.0-rc.3</version>
+	<version>2.0.0-rc.4</version>
 	<licence>agpl</licence>
 	<author>Nextcloud GmbH</author>
 	<namespace>EndToEndEncryption</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "end_to_end_encryption",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "end_to_end_encryption",
-      "version": "2.0.0-rc.3",
+      "version": "2.0.0-rc.4",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "end_to_end_encryption",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0-rc.4",
   "private": true,
   "description": "Provides the necessary endpoint to enable End-to-End encryption.",
   "homepage": "https://github.com/nextcloud/end_to_end_encryption#readme",


### PR DESCRIPTION
* fix(sharing): consolidate share tab and ensure user keys are used by @susnux in https://github.com/nextcloud/end_to_end_encryption/pull/1307
* fix(sharing): hide native sharing sections by @susnux in https://github.com/nextcloud/end_to_end_encryption/pull/1309
* feat(sharing): allow to create read only shares by @susnux in https://github.com/nextcloud/end_to_end_encryption/pull/1308
* fix(sharing): adjusted information about sharing by @susnux in https://github.com/nextcloud/end_to_end_encryption/pull/1310
* fix: ensure new files and folders will be created with unique names by @susnux in https://github.com/nextcloud/end_to_end_encryption/pull/1311
* refactor: Use modern event listener by @CarlSchwan in https://github.com/nextcloud/end_to_end_encryption/pull/1313
