### PR TITLE
fix: use 128bit AES for files

### DIFF
--- a/src/middleware/usePutInterceptor.ts
+++ b/src/middleware/usePutInterceptor.ts
@@ -45,7 +45,7 @@ export async function usePutInterceptor(context: FetchContext, next: () => Promi
 
 	logger.debug('Encrypting file for PUT', { filename })
 	const key = await globalThis.crypto.subtle.generateKey(
-		{ name: 'AES-GCM', length: 256 },
+		{ name: 'AES-GCM', length: 128 },
 		true,
 		['encrypt', 'decrypt'],
 	)


### PR DESCRIPTION
While we can read files with any AES key size (128 and 256bit both can be decrypted), the desktop client cannot and will fail. As per RFC only 128bit is officially supported so we need to hard code that for now.