### PR TITLE
perf: Replace getByid with getFirstNodeById

### DIFF
--- a/lib/Controller/MetaDataController.php
+++ b/lib/Controller/MetaDataController.php
@@ -281,8 +281,8 @@ class MetaDataController extends OCSController {
 			throw new OCSForbiddenException($this->l10n->t('You are not allowed to create the lock'));
 		}
 
-		$nodes = $userFolder->getById($id);
-		if (!isset($nodes[0]) || !$nodes[0] instanceof Folder) {
+		$node = $userFolder->getFirstNodeById($id);
+		if (!$node instanceof Folder) {
 			throw new OCSForbiddenException($this->l10n->t('You are not allowed to create the lock'));
 		}
 

--- a/lib/Controller/V1/LockingController.php
+++ b/lib/Controller/V1/LockingController.php
@@ -91,8 +91,8 @@ class LockingController extends OCSController {
 			throw $e;
 		}
 
-		$nodes = $userFolder->getById($id);
-		if (!isset($nodes[0]) || !$nodes[0] instanceof Folder) {
+		$node = $userFolder->getFirstNodeById($id);
+		if (!$node instanceof Folder) {
 			throw new OCSForbiddenException($this->l10n->t('You are not allowed to create the lock'));
 		}
 
@@ -129,12 +129,12 @@ class LockingController extends OCSController {
 			throw new OCSForbiddenException($this->l10n->t('You are not allowed to remove the lock'));
 		}
 
-		$nodes = $userFolder->getById($id);
-		if (!isset($nodes[0]) || !$nodes[0] instanceof Folder) {
+		$node = $userFolder->getFirstNodeById($id);
+		if (!$node instanceof Folder) {
 			throw new OCSForbiddenException($this->l10n->t('You are not allowed to remove the lock'));
 		}
 
-		$hadChanges = $this->fileService->finalizeChanges($nodes[0]) !== false;
+		$hadChanges = $this->fileService->finalizeChanges($node) !== false;
 
 		try {
 			$this->metaDataStorage->saveIntermediateFile($ownerId, $id);

--- a/lib/Controller/V1/MetaDataController.php
+++ b/lib/Controller/V1/MetaDataController.php
@@ -204,8 +204,8 @@ class MetaDataController extends OCSController {
 			throw $e;
 		}
 
-		$nodes = $userFolder->getById($id);
-		if (!isset($nodes[0]) || !$nodes[0] instanceof Folder) {
+		$node = $userFolder->getFirstNodeById($id);
+		if (!$node instanceof Folder) {
 			throw new OCSForbiddenException($this->l10n->t('You are not allowed to create the lock'));
 		}
 

--- a/lib/EncryptionManager.php
+++ b/lib/EncryptionManager.php
@@ -90,13 +90,8 @@ class EncryptionManager {
 	 */
 	protected function isValidFolder(int $id):void {
 		$this->accessManager->checkPermissions($id, true);
-
 		$node = $this->rootFolder->getFirstNodeById($id);
-		if ($node === null) {
-			throw new NotFoundException('No folder with ID ' . $id);
-		}
-
-		if (!($node instanceof Folder)) {
+		if (!$node instanceof Folder) {
 			throw new NotFoundException('No folder with ID ' . $id);
 		}
 

--- a/lib/MetaDataStorage.php
+++ b/lib/MetaDataStorage.php
@@ -11,6 +11,7 @@ namespace OCA\EndToEndEncryption;
 use OC\User\NoUserException;
 use OCA\EndToEndEncryption\Exceptions\MetaDataExistsException;
 use OCA\EndToEndEncryption\Exceptions\MissingMetaDataException;
+use OCP\Files\File;
 use OCP\Files\IAppData;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -355,12 +356,12 @@ class MetaDataStorage implements IMetaDataStorage {
 			throw new NotFoundException('No user-root for ' . $userId);
 		}
 
-		$ownerNodes = $userFolder->getById($id);
-		if (!isset($ownerNodes[0])) {
+		$ownerNode = $userFolder->getFirstNodeById($id);
+		if (!($ownerNode instanceof File)) {
 			throw new NotFoundException('No file for owner with ID ' . $id);
 		}
 
-		return $ownerNodes[0]->getPath();
+		return $ownerNode->getPath();
 	}
 
 	/**

--- a/lib/MetaDataStorageV1.php
+++ b/lib/MetaDataStorageV1.php
@@ -11,6 +11,7 @@ namespace OCA\EndToEndEncryption;
 use OC\User\NoUserException;
 use OCA\EndToEndEncryption\Exceptions\MetaDataExistsException;
 use OCA\EndToEndEncryption\Exceptions\MissingMetaDataException;
+use OCP\Files\File;
 use OCP\Files\IAppData;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -215,8 +216,8 @@ class MetaDataStorageV1 implements IMetaDataStorageV1 {
 			throw new NotFoundException('No user-root for ' . $userId);
 		}
 
-		$ownerNodes = $userFolder->getById($id);
-		if (!isset($ownerNodes[0])) {
+		$ownerNode = $userFolder->getFirstNodeById($id);
+		if ($ownerNode === null) {
 			throw new NotFoundException('No file for owner with ID ' . $id);
 		}
 	}
@@ -285,11 +286,11 @@ class MetaDataStorageV1 implements IMetaDataStorageV1 {
 			throw new NotFoundException('No user-root for ' . $userId);
 		}
 
-		$ownerNodes = $userFolder->getById($id);
-		if (!isset($ownerNodes[0])) {
+		$ownerNode = $userFolder->getFirstNodeById($id);
+		if (!($ownerNode instanceof File)) {
 			throw new NotFoundException('No file for owner with ID ' . $id);
 		}
 
-		return $ownerNodes[0]->getPath();
+		return $ownerNode->getPath();
 	}
 }

--- a/lib/RollbackService.php
+++ b/lib/RollbackService.php
@@ -90,12 +90,11 @@ class RollbackService {
 				continue;
 			}
 
-			$nodes = $userFolder->getById($lock->getId());
-			if (!isset($nodes[0]) || !$nodes[0] instanceof Folder) {
+			$node = $userFolder->getFirstNodeById($lock->getId());
+			if (!$node instanceof Folder) {
 				continue;
 			}
 
-			$node = $nodes[0];
 			// If the time that passed since the node was last modified
 			// is bigger than the time to live, do nothing
 			if ($node->getMTime() > $olderThanTimestamp) {

--- a/lib/RollbackServiceV1.php
+++ b/lib/RollbackServiceV1.php
@@ -88,12 +88,11 @@ class RollbackServiceV1 {
 				continue;
 			}
 
-			$nodes = $userFolder->getById($lock->getId());
-			if (!isset($nodes[0]) || !$nodes[0] instanceof Folder) {
+			$node = $userFolder->getFirstNodeById($lock->getId());
+			if (!$node instanceof Folder) {
 				continue;
 			}
 
-			$node = $nodes[0];
 			// If the time that passed since the node was last modified
 			// is bigger than the time to live, do nothing
 			if ($node->getMTime() > $olderThanTimestamp) {

--- a/tests/Unit/MetaDataStorageV1Test.php
+++ b/tests/Unit/MetaDataStorageV1Test.php
@@ -590,15 +590,15 @@ class MetaDataStorageV1Test extends TestCase {
 
 			if ($emptyOwnerRoot) {
 				$ownerRoot->expects($this->once())
-					->method('getById')
+					->method('getFirstNodeById')
 					->with(42)
-					->willReturn([]);
+					->willReturn(null);
 			} else {
 				$ownerNode = $this->createMock(Node::class);
 				$ownerRoot->expects($this->once())
-					->method('getById')
+					->method('getFirstNodeById')
 					->with(42)
-					->willReturn([$ownerNode]);
+					->willReturn($ownerNode);
 			}
 		}
 

--- a/tests/Unit/RollbackServiceTest.php
+++ b/tests/Unit/RollbackServiceTest.php
@@ -147,21 +147,21 @@ class RollbackServiceTest extends TestCase {
 			->willReturn(200);
 
 		$userFolder3->expects($this->once())
-			->method('getById')
+			->method('getFirstNodeById')
 			->with(100003)
-			->willReturn([$node3]);
+			->willReturn($node3);
 		$userFolder4->expects($this->once())
-			->method('getById')
+			->method('getFirstNodeById')
 			->with(100004)
-			->willReturn([$node4]);
+			->willReturn($node4);
 		$userFolder5->expects($this->once())
-			->method('getById')
+			->method('getFirstNodeById')
 			->with(100005)
-			->willReturn([$node5]);
+			->willReturn($node5);
 		$userFolder6->expects($this->once())
-			->method('getById')
+			->method('getFirstNodeById')
 			->with(100006)
-			->willReturn([$node6]);
+			->willReturn($node6);
 
 		$this->fileService->expects($this->exactly(3))
 			->method('revertChanges')

--- a/tests/Unit/RollbackServiceV1Test.php
+++ b/tests/Unit/RollbackServiceV1Test.php
@@ -147,21 +147,21 @@ class RollbackServiceV1Test extends TestCase {
 			->willReturn(200);
 
 		$userFolder3->expects($this->once())
-			->method('getById')
+			->method('getFirstNodeById')
 			->with(100003)
-			->willReturn([$node3]);
+			->willReturn($node3);
 		$userFolder4->expects($this->once())
-			->method('getById')
+			->method('getFirstNodeById')
 			->with(100004)
-			->willReturn([$node4]);
+			->willReturn($node4);
 		$userFolder5->expects($this->once())
-			->method('getById')
+			->method('getFirstNodeById')
 			->with(100005)
-			->willReturn([$node5]);
+			->willReturn($node5);
 		$userFolder6->expects($this->once())
-			->method('getById')
+			->method('getFirstNodeById')
 			->with(100006)
-			->willReturn([$node6]);
+			->willReturn($node6);
 
 		$this->fileService->expects($this->exactly(3))
 			->method('revertChanges')


### PR DESCRIPTION
We only need the first node anyway and getFirstNodeById is faster.