### PR TITLE
fix: Folder permissions on creation

### DIFF
--- a/src/components/CreateFolderDialog/CreateFolderDialogStepFolderName.vue
+++ b/src/components/CreateFolderDialog/CreateFolderDialogStepFolderName.vue
@@ -87,7 +87,7 @@ async function createFolder(): Promise<true | void> {
 		root: defaultRootPath,
 		crtime: new Date(),
 		mtime: new Date(),
-		permissions: Permission.READ, // TODO: allow more permissions once we support that
+		permissions: Permission.ALL,
 		size: 0, // its empty for now
 		attributes: {
 			'e2ee-is-encrypted': 1,


### PR DESCRIPTION
Now that other operation are supported by the web UI, we can use all permissions.