### PR TITLE
chore: Prepare v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@
 
 <!-- All notable changes to this project will be documented in this file so they will be shown in the Nextcloud app store "changes"-section -->
 
+## v2.0.1 - 2026-03-27
+
+### Fixed
+
+* feat(api): Hint clients towards using the proper API version [\#1520](https://github.com/nextcloud/end_to_end_encryption/pull/1520)
+* fix(keys): Properly handle `shareToken` for public encrypted shares [\#1527](https://github.com/nextcloud/end_to_end_encryption/pull/1527)
+* fix: skip trashbin on move [\#1532](https://github.com/nextcloud/end_to_end_encryption/pull/1532)
+* fix(lock): Write counter after creating the lock [\#1533](https://github.com/nextcloud/end_to_end_encryption/pull/1533)
+* fix: add throttling to all public page controllers [\#1531](https://github.com/nextcloud/end_to_end_encryption/pull/1531)
+
+### Changed
+
+* Updated dependencies
+
 ## v2.0.0 - 2026-02-05
 ### Added
 * Setup end-to-end encryption in the web interface.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -55,7 +55,7 @@ The clients and the web interface will handle the encryption and decryption proc
 Meaning that some apps in the web interface do not work with encrypted files.
 
 	]]></description>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<licence>agpl</licence>
 	<author>Nextcloud GmbH</author>
 	<namespace>EndToEndEncryption</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "end_to_end_encryption",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "end_to_end_encryption",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "end_to_end_encryption",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Provides the necessary endpoint to enable End-to-End encryption.",
   "homepage": "https://github.com/nextcloud/end_to_end_encryption#readme",


### PR DESCRIPTION
## What's Changed

* [stable31] Update nextcloud/ocp dependency by @nextcloud-command in https://github.com/nextcloud/end_to_end_encryption/pull/1551
* [stable31] Fix npm audit by @nextcloud-command in https://github.com/nextcloud/end_to_end_encryption/pull/1553
* [stable31] feat(api): Hint clients towards using the proper API version by @backportbot[bot] in https://github.com/nextcloud/end_to_end_encryption/pull/1522
* [stable31] fix(lock): Write counter after creating the lock by @backportbot[bot] in https://github.com/nextcloud/end_to_end_encryption/pull/1535
* [stable31] fix: add throttling to all public page controllers by @backportbot[bot] in https://github.com/nextcloud/end_to_end_encryption/pull/1560
