### PR TITLE
chore: Prepare v1.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 1.15.5 - 2026-03-27
+
+## What's Changed
+
+## Added
+
+* feat(api): Hint clients towards using the proper API version [#1525](https://github.com/nextcloud/end_to_end_encryption/pull/1525)
+
 ## Release 1.11.0-beta.1
 
 - Compatibility with NC 25

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<info xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance"
-	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>end_to_end_encryption</id>
 	<name>End-to-End Encryption</name>
 	<summary>End-to-end encryption endpoint</summary>
@@ -9,19 +9,20 @@ Provides the necessary endpoint to enable end-to-end encryption.
 
 **Notice:** E2EE is currently not compatible to be used together with server-side encryption
 	]]></description>
-	<version>1.15.4</version>
+	<version>1.15.5</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<namespace>EndToEndEncryption</namespace>
 	<types>
-		<filesystem/>
-		<dav/>
+		<filesystem />
+		<dav />
 	</types>
 	<category>files</category>
 	<website>https://github.com/nextcloud/end_to_end_encryption</website>
 	<bugs>https://github.com/nextcloud/end_to_end_encryption/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/end_to_end_encryption.git</repository>
-	<screenshot>https://raw.githubusercontent.com/nextcloud/end_to_end_encryption/master/screenshots/e2ee-filelisting.png</screenshot>
+	<screenshot>
+		https://raw.githubusercontent.com/nextcloud/end_to_end_encryption/master/screenshots/e2ee-filelisting.png</screenshot>
 	<dependencies>
 		<nextcloud min-version="29" max-version="29" />
 	</dependencies>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "end_to_end_encryption",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "end_to_end_encryption",
-      "version": "1.15.4",
+      "version": "1.15.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "end_to_end_encryption",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "description": "Provides the necessary endpoint to enable End-to-End encryption.",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What's Changed

## Added

* feat(api): Hint clients towards using the proper API version [#1525](https://github.com/nextcloud/end_to_end_encryption/pull/1525)