### PR TITLE
chore: Prepare v1.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Release 1.14.6 - 2026-03-27
+
+## What's Changed
+
+## Added
+
+* feat(api): Hint clients towards using the proper API version [#1526](https://github.com/nextcloud/end_to_end_encryption/pull/1526)
+
+## Changed
+
+- Updated dependencies
+
 ## Release 1.11.0-beta.1
 
 - Compatibility with NC 25

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@ Provides the necessary endpoint to enable end-to-end encryption.
 
 **Notice:** E2EE is currently not compatible to be used together with server-side encryption
 	]]></description>
-	<version>1.14.5</version>
+	<version>1.14.6</version>
 	<licence>agpl</licence>
 	<author>Bjoern Schiessle</author>
 	<namespace>EndToEndEncryption</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "end_to_end_encryption",
-  "version": "1.14.0",
+  "version": "1.14.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "end_to_end_encryption",
-      "version": "1.14.0",
+      "version": "1.14.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "end_to_end_encryption",
-  "version": "1.14.0",
+  "version": "1.14.6",
   "description": "Provides the necessary endpoint to enable End-to-End encryption.",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## What's Changed

## Added

* feat(api): Hint clients towards using the proper API version [#1526](https://github.com/nextcloud/end_to_end_encryption/pull/1526)

## Changed

- Updated dependencies
