### PR TITLE
fix: properly handle large encrypted file downloads

### DIFF
--- a/src/components/DownloadFolderDialog.vue
+++ b/src/components/DownloadFolderDialog.vue
@@ -67,6 +67,7 @@ async function startDownload() {
  * @param target - The target directory handle
  */
 async function downloadFile(name: string, path: string, target: FileSystemDirectoryHandle) {
+	const oldValue = filesDone.value || 0
 	try {
 		logger.debug('Downloading encrypted file', { name, path })
 		const content = await Array.fromAsync(target.keys())
@@ -74,17 +75,17 @@ async function downloadFile(name: string, path: string, target: FileSystemDirect
 
 		// The response will be decrypted as usual by the proxy.
 		const response = await window.fetch(path)
+		filesDone.value! += 0.25
+
 		const file = await target.getFileHandle(filename, { create: true })
 		const stream = await file.createWritable()
 		await stream.write(await response.arrayBuffer())
 		stream.close()
-
-		await new Promise((r) => window.setTimeout(r, 3000))
 	} catch (error) {
 		logger.error('Error downloading file', { error, name, path })
 		filesError.value.push(name)
 	} finally {
-		filesDone.value!++
+		filesDone.value = oldValue + 1
 	}
 }
 

--- a/src/files_actions/downloadUnencryptedAction.spec.ts
+++ b/src/files_actions/downloadUnencryptedAction.spec.ts
@@ -3,11 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { showLoading } from '@nextcloud/dialogs'
 import { DefaultType, File, Folder, Permission, View } from '@nextcloud/files'
 import { defaultRemoteURL } from '@nextcloud/files/dav'
 import { describe, expect, test, vi } from 'vitest'
 import { stringToBuffer } from '../services/bufferUtils.ts'
 import Action from './downloadUnencryptedAction.ts'
+
+vi.mock('@nextcloud/dialogs', { spy: true })
 
 const view = new View({
 	getContents: async () => {
@@ -57,6 +60,9 @@ test('all properties are set correctly', () => {
 })
 
 test('exec method calls downloadNodes', async () => {
+	vi.mocked(showLoading)
+		.mockImplementationOnce(() => ({ hideToast: vi.fn() }))
+
 	const spy = vi.spyOn(window, 'fetch')
 		.mockResolvedValueOnce(new Response(stringToBuffer('decrypted content')))
 
@@ -71,6 +77,7 @@ test('exec method calls downloadNodes', async () => {
 	expect(spy).toHaveBeenCalledWith(encryptedFile.encodedSource)
 	expect(element.href).toContain('blob:')
 	expect(element.click).toHaveBeenCalled()
+	expect(showLoading).toHaveBeenCalledOnce()
 })
 
 describe('enabled method', () => {

--- a/src/files_actions/downloadUnencryptedAction.ts
+++ b/src/files_actions/downloadUnencryptedAction.ts
@@ -6,10 +6,12 @@
 import type { IFileAction, INode } from '@nextcloud/files'
 
 import ArrowDownSvg from '@mdi/svg/svg/arrow-down.svg?raw'
+import { showLoading } from '@nextcloud/dialogs'
 import { DefaultType, FileType } from '@nextcloud/files'
 import { t } from '@nextcloud/l10n'
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import { defineAsyncComponent } from 'vue'
+import logger from '../services/logger.ts'
 import { isDownloadable } from '../services/permissions.ts'
 
 const DownloadFolderDialog = defineAsyncComponent(() => import('../components/DownloadFolderDialog.vue'))
@@ -21,14 +23,24 @@ const DownloadFolderDialog = defineAsyncComponent(() => import('../components/Do
  */
 async function downloadNode(file: INode) {
 	// Decryption happens in the proxy.
+	logger.debug('Triggering download of unencrypted file', { file })
 	const response = await fetch(file.encodedSource)
-	const decryptedFileContent = await response.arrayBuffer()
-	const blob = new Blob([decryptedFileContent], { type: file.mime })
+	const toast = showLoading(t('end_to_end_encryption', 'Preparing download for {file}', { file: file.displayname }))
 
-	const link = document.createElement('a')
-	link.href = window.URL.createObjectURL(blob)
-	link.download = file.displayname
-	link.click()
+	try {
+		logger.debug('Received response for file download')
+		const decryptedFileContent = await response.arrayBuffer()
+		const blob = new Blob([decryptedFileContent], { type: file.mime })
+
+		logger.debug('Created blob for decrypted file, starting download')
+		const link = document.createElement('a')
+		link.href = window.URL.createObjectURL(blob)
+		link.download = file.displayname
+		logger.debug('Created download link for decrypted file, starting download')
+		link.click()
+	} finally {
+		toast.hideToast()
+	}
 }
 
 export default {
@@ -67,7 +79,7 @@ export default {
 
 	async exec({ nodes }) {
 		const node = nodes[0]
-		if (node.type === FileType.Folder) {
+		if (node.type === FileType.Folder || (node.size && (node.size > 100 * 1024 * 1024) && window.showDirectoryPicker !== undefined)) {
 			await spawnDialog(DownloadFolderDialog, {
 				nodes,
 			})

--- a/src/middleware/useGetInterceptor.ts
+++ b/src/middleware/useGetInterceptor.ts
@@ -7,6 +7,8 @@ import type { FetchContext } from '@rxliuli/vista'
 import type { IMetadataFile } from '../models/metadata.d.ts'
 import type { Metadata } from '../models/Metadata.ts'
 
+import { showError, showLoading } from '@nextcloud/dialogs'
+import { t } from '@nextcloud/l10n'
 import { basename, dirname } from '@nextcloud/paths'
 import { base64ToBuffer } from '../services/bufferUtils.ts'
 import { decryptWithAES, loadAESPrivateKey } from '../services/crypto.ts'
@@ -40,7 +42,16 @@ export async function useGetInterceptor(context: FetchContext, next: () => Promi
 		throw new Error('Could not find file in metadata')
 	}
 
-	context.res = await decryptFile(response, fileInfo)
+	const loading = showLoading(t('end_to_end_encryption', 'Decrypting {file}', { file: fileInfo.filename }))
+	try {
+		context.res = await decryptFile(response, fileInfo)
+	} catch (error) {
+		logger.error('Error occurred while decrypting file', { error })
+		showError(t('end_to_end_encryption', 'An error occurred while decrypting the file. Please try downloading the file again.'))
+		throw error
+	} finally {
+		loading.hideToast()
+	}
 }
 
 /**
@@ -50,7 +61,7 @@ export async function useGetInterceptor(context: FetchContext, next: () => Promi
  * @param fileInfo - The file encryption info
  */
 async function decryptFile(response: Response, fileInfo: IMetadataFile): Promise<Response> {
-	logger.debug('Decrypting encrypted file', { response, fileInfo })
+	logger.debug('Decrypting encrypted file', { fileInfo })
 	const decryptedFileContent = await decryptWithAES(
 		new Uint8Array(await response.arrayBuffer()),
 		await loadAESPrivateKey(base64ToBuffer(fileInfo.key)),

--- a/src/services/webDavProxy.ts
+++ b/src/services/webDavProxy.ts
@@ -64,7 +64,11 @@ function wrapInterceptor(middleware: BaseMiddleware<FetchContext>, method: strin
 		try {
 			await middleware(context, next)
 		} catch (error) {
-			logger.error(`Error in ${context.req.method} interceptor`, { error, request: context.req })
+			if (error instanceof DOMException && error.name === 'AbortError') {
+				logger.debug('Request was aborted', { error, request: context.req })
+			} else {
+				logger.error(`Error in ${context.req.method} interceptor`, { error, request: context.req })
+			}
 			throw error
 		}
 	}


### PR DESCRIPTION
This improves the situation when we have to download huge files:
1. Add some visual process to make user aware it is still running
2. If the file is large and we support filesystem API use this to use less memory (do not double memory usage).
3. Add some more logging for debugging issues