### PR TITLE
chore: release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 <!-- All notable changes to this project will be documented in this file so they will be shown in the Nextcloud app store "changes"-section -->
 
+## v2.1.1 - 2026-05-13
+### Fixed
+* fix: properly handle large encrypted file downloads \([\#1698](https://github.com/nextcloud/end_to_end_encryption/pull/1698)\)
+
+### Changed
+* Updated dependencies
+
 ## v2.1.0 - 2026-04-07
 ### Added
 * Allow to convert files uploaded by public end-to-end encrypted file drops to regular files within the browser \([\#1594](https://github.com/nextcloud/end_to_end_encryption/pull/1594)\).

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -55,7 +55,7 @@ The clients and the web interface will handle the encryption and decryption proc
 Meaning that some apps in the web interface do not work with encrypted files.
 
 	]]></description>
-	<version>2.1.0</version>
+	<version>2.1.1</version>
 	<licence>agpl</licence>
 	<author>Nextcloud GmbH</author>
 	<namespace>EndToEndEncryption</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "end_to_end_encryption",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "end_to_end_encryption",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "end_to_end_encryption",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "description": "Provides the necessary endpoint to enable End-to-End encryption.",
   "homepage": "https://github.com/nextcloud/end_to_end_encryption#readme",


### PR DESCRIPTION
### Fixed
* fix: properly handle large encrypted file downloads \([\#1698](https://github.com/nextcloud/end_to_end_encryption/pull/1698)\)

### Changed
* Updated dependencies