### PR TITLE
chore: adjust code for new stable-versions approach

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,7 +54,7 @@ updates:
 
 # Main stableXX npm
 - package-ecosystem: npm
-  target-branch: stable34
+  target-branch: stable-2
   directory: "/"
   schedule:
     interval: weekly
@@ -69,29 +69,9 @@ updates:
     - "3. to review"
     - "dependencies"
   ignore:
-    # ignore all GitHub linguist patch updates
+    # No major updates on stable branches.
     - dependency-name: "*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
-
-- package-ecosystem: npm
-  target-branch: stable33
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: saturday
-    time: "03:00"
-    timezone: Europe/Paris
-  cooldown:
-    default-days: 10
-  open-pull-requests-limit: 5
-  versioning-strategy: increase
-  labels:
-    - "3. to review"
-    - "dependencies"
-  ignore:
-    # ignore all GitHub linguist patch updates
-    - dependency-name: "*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      update-types: ["version-update:semver-major"]
   groups:
     vite:
       patterns:
@@ -102,6 +82,7 @@ updates:
         - "vitest"
         - "@vitest/*"
 
+# Old stable
 - package-ecosystem: npm
   target-branch: stable32
   directory: "/"
@@ -118,9 +99,9 @@ updates:
     - "3. to review"
     - "dependencies"
   ignore:
-    # ignore all GitHub linguist patch updates
+    # No major updates on stable branches.
     - dependency-name: "*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      update-types: ["version-update:semver-major"]
   groups:
     vite:
       patterns:

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -26,8 +26,7 @@ jobs:
       matrix:
         branches:
           - ${{ github.event.repository.default_branch }}
-          - 'stable34'
-          - 'stable33'
+          - 'stable-2'
           - 'stable32'
 
     name: npm-audit-fix-${{ matrix.branches }}

--- a/.github/workflows/npm-audit-fix.yml.patch
+++ b/.github/workflows/npm-audit-fix.yml.patch
@@ -1,0 +1,14 @@
+diff --git a/.github/workflows/npm-audit-fix.yml b/.github/workflows/npm-audit-fix.yml
+index 82fa89f5..1c19ed2b 100644
+--- a/.github/workflows/npm-audit-fix.yml
++++ b/.github/workflows/npm-audit-fix.yml
+@@ -26,8 +26,7 @@ jobs:
+       matrix:
+         branches:
+           - ${{ github.event.repository.default_branch }}
+-          - 'stable34'
+-          - 'stable33'
++          - 'stable-2'
+           - 'stable32'
+ 
+     name: npm-audit-fix-${{ matrix.branches }}

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -26,8 +26,7 @@ jobs:
       matrix:
         branches:
           - ${{ github.event.repository.default_branch }}
-          - 'stable34'
-          - 'stable33'
+          - 'stable-2'
           - 'stable32'
 
     name: update-nextcloud-ocp-${{ matrix.branches }}

--- a/.github/workflows/update-nextcloud-ocp.yml.patch
+++ b/.github/workflows/update-nextcloud-ocp.yml.patch
@@ -1,0 +1,14 @@
+diff --git a/.github/workflows/update-nextcloud-ocp.yml b/.github/workflows/update-nextcloud-ocp.yml
+index 55f6c217..75b48972 100644
+--- a/.github/workflows/update-nextcloud-ocp.yml
++++ b/.github/workflows/update-nextcloud-ocp.yml
+@@ -26,8 +26,7 @@ jobs:
+       matrix:
+         branches:
+           - ${{ github.event.repository.default_branch }}
+-          - 'stable34'
+-          - 'stable33'
++          - 'stable-2'
+           - 'stable32'
+ 
+     name: update-nextcloud-ocp-${{ matrix.branches }}

--- a/README.md
+++ b/README.md
@@ -169,3 +169,12 @@ Therefore we recommend that every contributor adds the following line to the [AU
 For this please make sure to sign-off your commits if you want to contribute code (`git commit -s`).
 
 Please read the [Code of Conduct](https://nextcloud.com/community/code-of-conduct/). This document offers some guidance to ensure Nextcloud participants can cooperate effectively in a positive and inspiring atmosphere and to explain how together we can strengthen and support each other.
+
+### Stable branches
+
+Before Nextcloud 33 each we published one app version per Nextcloud version
+and maintained a branch per Nextcloud versions like `stable32` for Nextcloud 32.
+
+Since Nextcloud 33 we switched to a versions based branch process,
+where we will keep support of multiple Nextcloud versions within a single app version.
+So the new naming schema is e.g. `stable-2` for the v2.x series of this app.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -36,7 +36,7 @@ SPDX-FileCopyrightText = "2018-2024 Google LLC"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
-path = [".github/CODEOWNERS", "tsconfig.json", "__tests__/tsconfig.json"]
+path = [".github/CODEOWNERS", ".github/workflows/*.patch", "tsconfig.json", "__tests__/tsconfig.json"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later"


### PR DESCRIPTION
Adjust dependabot for the new branches:

stable32 and before for legacy versions.
stable33 will be renamed `stable-2` for v2.x of this app targeting Nextcloud 33, 34 (and likely further).