### PR TITLE
fix: enforce using SHA256

### DIFF
--- a/lib/SignatureHandler.php
+++ b/lib/SignatureHandler.php
@@ -34,7 +34,13 @@ class SignatureHandler {
 	 */
 	public function sign(string $csr): string {
 		$systemKeys = $this->identityProofManager->getSystemKey();
-		$signedCertificate = openssl_csr_sign($csr, null, $systemKeys->getPrivate(), $this->validity);
+		$signedCertificate = openssl_csr_sign(
+			$csr,
+			null,
+			$systemKeys->getPrivate(),
+			$this->validity,
+			['digest_alg' => 'sha256'],
+		);
 		if ($signedCertificate === false) {
 			throw new BadMethodCallException('could not sign the CSR, please make sure to submit a valid CSR');
 		}


### PR DESCRIPTION
- closes https://github.com/nextcloud/end_to_end_encryption/issues/1567

Some faulty openSSL configurations use still SHA1, causing problems.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
