### PR TITLE
fix: only throttle public requests

### DIFF
--- a/lib/Controller/KeyController.php
+++ b/lib/Controller/KeyController.php
@@ -176,7 +176,10 @@ class KeyController extends OCSController {
 				$result['public-keys'][$uid] = $publicKey;
 			} catch (NotFoundException $e) {
 				$this->logger->debug('Could not find the public key of the user: ' . $uid, ['exception' => $e]);
-				return $this->throttleRequest(Http::STATUS_NOT_FOUND, 'Could not find the public key belonging to the user ' . $uid);
+				if ($this->userId === null) {
+					return $this->throttleRequest(Http::STATUS_NOT_FOUND, 'Could not find the public key belonging to the user ' . $uid);
+				}
+				throw new OCSNotFoundException('Could not find the public key belonging to the user ' . $uid);
 			} catch (Exception $e) {
 				$this->logger->critical($e->getMessage(), ['exception' => $e, 'app' => $this->appName]);
 				throw new OCSBadRequestException($this->l10n->t('Internal error'));

--- a/tests/Unit/Controller/KeyControllerTest.php
+++ b/tests/Unit/Controller/KeyControllerTest.php
@@ -28,7 +28,7 @@ use Test\TestCase;
 
 class KeyControllerTest extends TestCase {
 
-	private string $userId;
+	private ?string $userId;
 	private IRequest&MockObject $request;
 	private IKeyStorage&MockObject $keyStorage;
 	private SignatureHandler&MockObject $signatureHandler;
@@ -360,7 +360,32 @@ AYzYQFPtjsDZ4Tju4VZKM4YpF2GwQgT7zhzDBvywGPqvfw==
 			->method('t')
 			->willReturnCallback(static fn ($string, $args): string => vsprintf($string, $args));
 
-		$response = $this->controller->getPublicKeys($users);
+		$this->expectException(OCSNotFoundException::class);
+		$this->controller->getPublicKeys($users);
+	}
+
+	public function testGetPublicKeysNotFoundExceptionPublicPage(): void {
+		$users = '["user1","user2","user3"]';
+
+		$this->keyStorage->expects($this->once())
+			->method('getPublicKey')
+			->willThrowException(new NotFoundException());
+
+		$this->l10n->expects($this->any())
+			->method('t')
+			->willReturnCallback(static fn ($string, $args): string => vsprintf($string, $args));
+
+		$this->userId = null;
+		$controller = new KeyController(
+			$this->request,
+			$this->userId,
+			$this->keyStorage,
+			$this->signatureHandler,
+			$this->logger,
+			$this->l10n,
+			$this->shareManager,
+		);
+		$response = $controller->getPublicKeys($users);
 		self::assertEquals($response->getStatus(), 404);
 		self::assertEquals($response->getData(), ['message' => 'Could not find the public key belonging to the user user1']);
 	}


### PR DESCRIPTION
When trying to share with users we need to filter all users for set-up e2ee, so this endpoint returns 404 quite often an cannot be brute force protected for logged-in users.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
