### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -56,7 +56,7 @@ Meaning that some apps in the web interface do not work with encrypted files.
 
 	]]></description>
 	<version>3.0.0-dev.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author>Nextcloud GmbH</author>
 	<namespace>EndToEndEncryption</namespace>
 	<types>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "nextcloud/end_to_end_encryption",
 	"description": "-",
 	"type": "project",
-	"license": "AGPL",
+	"license": "AGPL-3.0-or-later",
 	"authors": [
 		{
 			"name": "Nextcloud GmbH and Nextcloud contributors"


### PR DESCRIPTION
unifying the license string, already used in package.json and supported in info.xml since 31, so no issue given min-version is set to 35 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
