### PR TITLE
fix(propfind): properly handle PROPFIND when only a child is e2ee

### DIFF
--- a/__tests__/consts.spec.ts
+++ b/__tests__/consts.spec.ts
@@ -140,7 +140,7 @@ export const rootFolderPropfindResponse = `<?xml version="1.0"?>
 				<nc:system-tags />
 				<nc:rich-workspace></nc:rich-workspace>
 				<nc:rich-workspace-file></nc:rich-workspace-file>
-				<nc:e2ee-is-encrypted>1</nc:e2ee-metadata>
+				<nc:e2ee-is-encrypted>1</nc:e2ee-is-encrypted>
 				<nc:e2ee-metadata>${JSON.stringify(rootFolderMetadata)}</nc:e2ee-metadata>
 				<nc:e2ee-metadata-signature>${rootFolderMetadataSignature}</nc:e2ee-metadata-signature>
 			</d:prop>
@@ -326,7 +326,7 @@ export const subFolderPropfindResponse = `<?xml version="1.0"?>
                 <oc:size>778399</oc:size>
                 <nc:hidden>false</nc:hidden>
                 <nc:is-mount-root>false</nc:is-mount-root>
-                <nc:e2ee-is-encrypted>1</nc:e2ee-metadata>
+                <nc:e2ee-is-encrypted>1</nc:e2ee-is-encrypted>
                 <nc:e2ee-metadata>${JSON.stringify(subFolderMetadata)}</nc:e2ee-metadata>
                 <nc:e2ee-metadata-signature>${subFolderMetadataSignature}</nc:e2ee-metadata-signature>
                 <nc:reminder-due-date></nc:reminder-due-date>
@@ -553,6 +553,153 @@ export const unencryptedPropFindResponse = `<?xml version="1.0"?>
 				<nc:e2ee-metadata-signature />
 				<nc:note />
 				<nc:hide-download />
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+</d:multistatus>`
+
+// PROPFIND of an unencrypted folder that contains an unencrypted file,
+// an e2ee root folder and (e.g. with "Depth: infinity") a node inside that e2ee root
+export const mixedPropFindResponse = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns"
+	xmlns:nc="http://nextcloud.org/ns">
+	<d:response>
+		<d:href>/remote.php/dav/files/admin/</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:getetag>&quot;675b116c6ef00&quot;</d:getetag>
+				<d:getlastmodified>Thu, 12 Dec 2024 16:38:04 GMT</d:getlastmodified>
+				<d:creationdate>1970-01-01T00:00:00+00:00</d:creationdate>
+				<d:displayname>admin</d:displayname>
+				<d:quota-available-bytes>-3</d:quota-available-bytes>
+				<d:resourcetype>
+					<d:collection />
+				</d:resourcetype>
+				<nc:has-preview>false</nc:has-preview>
+				<nc:is-encrypted>0</nc:is-encrypted>
+				<nc:mount-type></nc:mount-type>
+				<oc:fileid>1</oc:fileid>
+				<oc:owner-display-name>admin</oc:owner-display-name>
+				<oc:owner-id>admin</oc:owner-id>
+				<oc:permissions>RGDNVCK</oc:permissions>
+				<oc:size>1000</oc:size>
+				<nc:hidden>false</nc:hidden>
+				<nc:is-mount-root>true</nc:is-mount-root>
+				<nc:e2ee-is-encrypted>0</nc:e2ee-is-encrypted>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength />
+				<d:getcontenttype />
+				<nc:e2ee-metadata />
+				<nc:e2ee-metadata-signature />
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+	<d:response>
+		<d:href>/remote.php/dav/files/admin/plain.txt</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength>10</d:getcontentlength>
+				<d:getcontenttype>text/plain</d:getcontenttype>
+				<d:getetag>&quot;f8797cf9677cd6d24d405c9778471000&quot;</d:getetag>
+				<d:getlastmodified>Thu, 12 Dec 2024 15:36:40 GMT</d:getlastmodified>
+				<d:creationdate>1970-01-01T00:00:00+00:00</d:creationdate>
+				<d:displayname>plain.txt</d:displayname>
+				<d:resourcetype />
+				<nc:has-preview>false</nc:has-preview>
+				<nc:mount-type></nc:mount-type>
+				<oc:fileid>2</oc:fileid>
+				<oc:owner-display-name>admin</oc:owner-display-name>
+				<oc:owner-id>admin</oc:owner-id>
+				<oc:permissions>RGDNVW</oc:permissions>
+				<oc:size>10</oc:size>
+				<nc:hidden>false</nc:hidden>
+				<nc:is-mount-root>false</nc:is-mount-root>
+				<nc:e2ee-is-encrypted>0</nc:e2ee-is-encrypted>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:quota-available-bytes />
+				<nc:is-encrypted />
+				<nc:e2ee-metadata />
+				<nc:e2ee-metadata-signature />
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+	<d:response>
+		<d:href>/remote.php/dav/files/admin/New%20folder/</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:getetag>&quot;675b116c6ef35&quot;</d:getetag>
+				<d:getlastmodified>Thu, 12 Dec 2024 16:38:04 GMT</d:getlastmodified>
+				<d:creationdate>1970-01-01T00:00:00+00:00</d:creationdate>
+				<d:displayname>New folder</d:displayname>
+				<d:quota-available-bytes>-3</d:quota-available-bytes>
+				<d:resourcetype>
+					<d:collection />
+				</d:resourcetype>
+				<nc:has-preview>false</nc:has-preview>
+				<nc:is-encrypted>1</nc:is-encrypted>
+				<nc:mount-type></nc:mount-type>
+				<oc:fileid>89</oc:fileid>
+				<oc:owner-display-name>admin</oc:owner-display-name>
+				<oc:owner-id>admin</oc:owner-id>
+				<oc:permissions>RGDNVCK</oc:permissions>
+				<oc:size>29</oc:size>
+				<nc:hidden>false</nc:hidden>
+				<nc:is-mount-root>false</nc:is-mount-root>
+				<nc:e2ee-is-encrypted>1</nc:e2ee-is-encrypted>
+				<nc:e2ee-metadata>${JSON.stringify(rootFolderMetadata)}</nc:e2ee-metadata>
+				<nc:e2ee-metadata-signature>${rootFolderMetadataSignature}</nc:e2ee-metadata-signature>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength />
+				<d:getcontenttype />
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+	<d:response>
+		<d:href>/remote.php/dav/files/admin/New%20folder/ad3b12554e0d4364854ae3e21b170152</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:getcontentlength>29</d:getcontentlength>
+				<d:getcontenttype>application/octet-stream</d:getcontenttype>
+				<d:getetag>&quot;f8797cf9677cd6d24d405c97784710dc&quot;</d:getetag>
+				<d:getlastmodified>Thu, 12 Dec 2024 15:36:40 GMT</d:getlastmodified>
+				<d:creationdate>1970-01-01T00:00:00+00:00</d:creationdate>
+				<d:displayname>ad3b12554e0d4364854ae3e21b170152</d:displayname>
+				<d:resourcetype />
+				<nc:has-preview>false</nc:has-preview>
+				<nc:mount-type></nc:mount-type>
+				<oc:fileid>237</oc:fileid>
+				<oc:owner-display-name>admin</oc:owner-display-name>
+				<oc:owner-id>admin</oc:owner-id>
+				<oc:permissions>RGDNVW</oc:permissions>
+				<oc:size>29</oc:size>
+				<nc:hidden>false</nc:hidden>
+				<nc:is-mount-root>false</nc:is-mount-root>
+				<nc:e2ee-is-encrypted>1</nc:e2ee-is-encrypted>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:quota-available-bytes />
+				<nc:is-encrypted />
+				<nc:e2ee-metadata />
+				<nc:e2ee-metadata-signature />
 			</d:prop>
 			<d:status>HTTP/1.1 404 Not Found</d:status>
 		</d:propstat>

--- a/src/files_actions/sharingAction.spec.ts
+++ b/src/files_actions/sharingAction.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { getCurrentUser } from '@nextcloud/auth'
+import { File, Folder, getSidebar, Permission, View } from '@nextcloud/files'
+import { defaultRemoteURL } from '@nextcloud/files/dav'
+import { isPublicShare } from '@nextcloud/sharing/public'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { sharingAction } from './sharingAction.ts'
+
+vi.mock('@nextcloud/auth', () => ({
+	getCurrentUser: vi.fn(),
+}))
+vi.mock('@nextcloud/sharing/public', () => ({
+	isPublicShare: vi.fn(),
+}))
+vi.mock('@nextcloud/files', async (importOriginal) => ({
+	...(await importOriginal()),
+	getSidebar: vi.fn(),
+}))
+
+beforeEach(() => {
+	vi.resetAllMocks()
+	vi.mocked(getCurrentUser).mockReturnValue({ uid: 'test', displayName: 'Test', isAdmin: false })
+	vi.mocked(isPublicShare).mockReturnValue(false)
+})
+
+const view = new View({
+	getContents: async () => {
+		throw new Error('Not implemented')
+	},
+	icon: '<svg></svg>',
+	name: 'Test View',
+	id: 'test_view',
+})
+
+const folder = new Folder({
+	owner: 'test',
+	source: defaultRemoteURL + '/files/test/folder',
+	root: '/files/test',
+	permissions: Permission.ALL,
+})
+
+const encryptedFolder = new Folder({
+	owner: 'test',
+	source: defaultRemoteURL + '/files/test/encrypted',
+	root: '/files/test',
+	permissions: Permission.ALL,
+	attributes: {
+		'e2ee-is-encrypted': 1,
+		'is-encrypted': 1,
+	},
+})
+
+const encryptedFile = new File({
+	owner: 'test',
+	source: defaultRemoteURL + '/files/test/encrypted/6dbd5008041f4103a24b45a6560ebe95',
+	root: '/files/test',
+	mime: 'application/octet-stream',
+	permissions: Permission.ALL,
+	attributes: {
+		'e2ee-is-encrypted': 1,
+	},
+})
+
+const contents = [] as File[]
+
+test('all properties are set correctly', () => {
+	expect(sharingAction.id).toBe('end_to_end_encryption::sharing')
+	expect(sharingAction.displayName({ nodes: [encryptedFolder], view, folder, contents })).toBe('Sharing options')
+	expect(sharingAction.iconSvgInline({ nodes: [encryptedFolder], view, folder, contents })).toContain('<svg')
+})
+
+test('exec method opens the sharing sidebar', async () => {
+	const open = vi.fn()
+	vi.mocked(getSidebar).mockReturnValue({ open } as never)
+
+	const result = await sharingAction.exec({ nodes: [encryptedFolder], view, folder, contents })
+	expect(result).toBeNull()
+	expect(open).toHaveBeenCalledOnce()
+	expect(open).toHaveBeenCalledWith(encryptedFolder, 'sharing')
+})
+
+describe('enabled method', () => {
+	test('is available', () => {
+		expect(sharingAction.enabled).toBeTypeOf('function')
+	})
+
+	test('returns false for no nodes', () => {
+		expect(sharingAction.enabled!({ nodes: [], view, folder, contents })).toBe(false)
+	})
+
+	test('returns false for multiple nodes', () => {
+		expect(sharingAction.enabled!({ nodes: [encryptedFolder, encryptedFile], view, folder, contents })).toBe(false)
+	})
+
+	test('returns false on public shares', () => {
+		vi.mocked(isPublicShare).mockReturnValue(true)
+		expect(sharingAction.enabled!({ nodes: [encryptedFolder], view, folder, contents })).toBe(false)
+	})
+
+	test('returns false without read permissions', () => {
+		const encryptedFolderClone = encryptedFolder.clone()
+		encryptedFolderClone.permissions = encryptedFolderClone.permissions & ~Permission.READ
+		expect(sharingAction.enabled!({ nodes: [encryptedFolderClone], view, folder, contents })).toBe(false)
+	})
+
+	test('returns false for non encrypted node', () => {
+		expect(sharingAction.enabled!({ nodes: [folder], view, folder, contents })).toBe(false)
+	})
+
+	test('returns false if the current user is not the owner', () => {
+		vi.mocked(getCurrentUser).mockReturnValue({ uid: 'other', displayName: 'Other', isAdmin: false })
+		expect(sharingAction.enabled!({ nodes: [encryptedFolder], view, folder, contents })).toBe(false)
+	})
+
+	test('returns false if there is no current user', () => {
+		vi.mocked(getCurrentUser).mockReturnValue(null)
+		expect(sharingAction.enabled!({ nodes: [encryptedFolder], view, folder, contents })).toBe(false)
+	})
+
+	test('returns true for an owned encrypted folder', () => {
+		expect(sharingAction.enabled!({ nodes: [encryptedFolder], view, folder, contents })).toBe(true)
+	})
+
+	test('returns true for an owned encrypted file', () => {
+		expect(sharingAction.enabled!({ nodes: [encryptedFile], view, folder, contents })).toBe(true)
+	})
+})

--- a/src/files_actions/sharingAction.ts
+++ b/src/files_actions/sharingAction.ts
@@ -39,11 +39,15 @@ export const sharingAction: IFileAction = {
 		}
 
 		// Only allow sharing for encrypted files if the user is the owner
-		if (node.owner === getCurrentUser()?.uid && node.attributes['e2ee-is-encrypted']) {
-			return true
+		if (!node.attributes['e2ee-is-encrypted']) {
+			return false
 		}
 
-		return false
+		if (node.owner !== getCurrentUser()?.uid) {
+			return false
+		}
+
+		return true
 	},
 
 	async exec({ nodes }) {

--- a/src/files_actions/sharingAction.ts
+++ b/src/files_actions/sharingAction.ts
@@ -1,0 +1,55 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { IFileAction } from '@nextcloud/files'
+
+import AccountPlusSvg from '@mdi/svg/svg/account-plus-outline.svg?raw'
+import { getCurrentUser } from '@nextcloud/auth'
+import { getSidebar, Permission } from '@nextcloud/files'
+import { t } from '@nextcloud/l10n'
+import { isPublicShare } from '@nextcloud/sharing/public'
+
+export const sharingAction: IFileAction = {
+	id: 'end_to_end_encryption::sharing',
+
+	iconSvgInline() {
+		return AccountPlusSvg
+	},
+
+	displayName() {
+		return t('files_sharing', 'Sharing options')
+	},
+
+	enabled({ nodes }) {
+		if (nodes.length !== 1) {
+			return false
+		}
+
+		// Do not leak information about users to public shares
+		if (isPublicShare()) {
+			return false
+		}
+
+		const node = nodes[0]
+		// Read permissions needed to open the sharing sidebar
+		if (!(node.permissions & Permission.READ)) {
+			return false
+		}
+
+		// Only allow sharing for encrypted files if the user is the owner
+		if (node.owner === getCurrentUser()?.uid && node.attributes['e2ee-is-encrypted']) {
+			return true
+		}
+
+		return false
+	},
+
+	async exec({ nodes }) {
+		const node = nodes[0]
+		const sidebar = getSidebar()
+		sidebar.open(node, 'sharing')
+		return null
+	},
+}

--- a/src/main-files.ts
+++ b/src/main-files.ts
@@ -8,6 +8,7 @@ import { registerDavProperty } from '@nextcloud/files/dav'
 import { loadState } from '@nextcloud/initial-state'
 import { isPublicShare } from '@nextcloud/sharing/public'
 import downloadUnencryptedAction from './files_actions/downloadUnencryptedAction.ts'
+import { sharingAction } from './files_actions/sharingAction.ts'
 import { registerNewEncryptedFolderEntry } from './files_newMenu/new-encrypted-folder.ts'
 import { setupEventBusProxy } from './services/eventBusProxy.ts'
 import { registerSharingSidebarSection } from './services/filesSharingSection.ts'
@@ -27,6 +28,7 @@ if ((userConfig.e2eeInBrowserEnabled || isPublicShare()) && browserSupportsWebCr
 	registerDavProperty('nc:e2ee-metadata-signature', { nc: 'http://nextcloud.org/ns' })
 	// Register file integrations
 	registerFileAction(downloadUnencryptedAction)
+	registerFileAction(sharingAction)
 	disableFileAction('download')
 	registerNewEncryptedFolderEntry()
 	// Register sharing integrations

--- a/src/middleware/usePropFindInterceptor.spec.ts
+++ b/src/middleware/usePropFindInterceptor.spec.ts
@@ -8,6 +8,7 @@ import { parseXML } from 'webdav'
 import {
 	adminMnemonic,
 	adminPrivateKeyInfo,
+	mixedPropFindResponse,
 	rootFilePropfindResponse,
 	rootFolderMetadata,
 	rootFolderMetadataSignature,
@@ -45,6 +46,54 @@ test('passes through non encrypted propfinds', async () => {
 	await usePropFindInterceptor(context, async () => {})
 	expect(spy).not.toHaveBeenCalled()
 	await expect(context.res.text()).resolves.toBe(unencryptedPropFindResponse)
+})
+
+test('Correctly adjust e2ee nodes in PROPFIND of an unencrypted folder', async () => {
+	const metadata = await RootMetadata.fromJson(rootFolderMetadata, 'admin', await decryptPrivateKey(adminPrivateKeyInfo, adminMnemonic))
+	metadataStore.getMetadata
+		// @ts-expect-error -- mocking for tests
+		.mockImplementation(async (path: string) => ({ metadata, path: path.replace(/\/+$/g, '') }))
+	metadataStore.setRawMetadata
+		// @ts-expect-error -- mocking for tests
+		.mockImplementation(async () => {})
+
+	const context = {
+		req: new Request('https://example.com/remote.php/dav/files/admin', { method: 'PROPFIND' }),
+		res: new Response(mixedPropFindResponse),
+		type: 'fetch' as const,
+	}
+
+	await usePropFindInterceptor(context, async () => {})
+
+	// the metadata shipped with the e2ee root child is cached
+	expect(metadataStore.setRawMetadata).toHaveBeenCalledTimes(1)
+	expect(metadataStore.setRawMetadata).toHaveBeenCalledWith(
+		'/remote.php/dav/files/admin/New%20folder',
+		89,
+		JSON.stringify(rootFolderMetadata),
+		rootFolderMetadataSignature,
+	)
+
+	const xml = await parseXML(await context.res.text())
+	expect(xml.multistatus.response).toHaveLength(4)
+	// the unencrypted PROPFIND target and the unencrypted sibling are kept untouched
+	expect(xml.multistatus.response[0]!.propstat?.prop.displayname).toBe('admin')
+	expect(xml.multistatus.response[0]!.propstat?.prop.permissions).toBe('RGDNVCK')
+	expect(xml.multistatus.response[1]!.propstat?.prop.displayname).toBe('plain.txt')
+	expect(xml.multistatus.response[1]!.propstat?.prop.getcontenttype).toBe('text/plain')
+	expect(xml.multistatus.response[1]!.propstat?.prop.permissions).toBe('RGDNVW')
+	// the e2ee root keeps its unencrypted name but loses the share permission
+	expect(xml.multistatus.response[2]!.propstat?.prop.displayname).toBe('New folder')
+	expect(xml.multistatus.response[2]!.propstat?.prop.permissions).toBe('GDNVCK')
+	// the node inside the e2ee root is decrypted
+	expect(xml.multistatus.response[3]!.propstat?.prop.displayname).toBe('test.txt')
+	expect(xml.multistatus.response[3]!.propstat?.prop.getcontenttype).toBe('text/plain')
+	expect(xml.multistatus.response[3]!.propstat?.prop.permissions).toBe('GDNVW')
+
+	// metadata is only resolved for the parent of the node inside the e2ee root,
+	// never for the unencrypted nodes or the e2ee root itself
+	expect(metadataStore.getMetadata).toHaveBeenCalledTimes(1)
+	expect(metadataStore.getMetadata).toHaveBeenCalledWith('/remote.php/dav/files/admin/New%20folder')
 })
 
 test('Correctly replace root file info in PROPFIND', async () => {

--- a/src/middleware/usePropFindInterceptor.ts
+++ b/src/middleware/usePropFindInterceptor.ts
@@ -5,7 +5,6 @@
 
 import type { FetchContext } from '@rxliuli/vista'
 import type { DAVResult, DAVResultResponse } from 'webdav'
-import type { Metadata } from '../models/Metadata.ts'
 
 import { dirname } from '@nextcloud/paths'
 import { XMLBuilder } from 'fast-xml-parser'
@@ -16,7 +15,7 @@ import * as metadataStore from '../store/metadata.ts'
 import * as taskStore from '../store/tasks.ts'
 
 /**
- * Callback to handle GET requests.
+ * Callback to handle PROPFIND requests.
  *
  * @param context - The fetch context
  * @param next - The next middleware function
@@ -32,115 +31,166 @@ export async function usePropFindInterceptor(context: FetchContext, next: () => 
 	const xml = await parseXML(body)
 	const stat = parseStat(xml, path, true)
 
-	if (!stat.props || String(stat.props['e2ee-is-encrypted']) !== '1') {
-		logger.debug('Node is not e2ee', { xml })
+	// The requested node itself might not be encrypted while the result still contains
+	// encrypted nodes, e.g. when listing an unencrypted folder that contains an e2ee root.
+	// So the encryption state has to be decided for each node individually.
+	const targetIsEncrypted = stat.props !== undefined && String(stat.props['e2ee-is-encrypted']) === '1'
+	const isEncryptedNode = (node: DAVResultResponse): boolean => (
+		// all nodes within an encrypted PROPFIND target are encrypted as well
+		targetIsEncrypted
+		|| String(node.propstat?.prop['e2ee-is-encrypted']) === '1'
+	)
+
+	if (!xml.multistatus.response.some(isEncryptedNode)) {
+		logger.debug('No e2ee nodes in PROPFIND result', { xml })
 		return
 	}
 
-	if (stat.type === 'directory') {
-		const {
-			fileid: fileId,
-			'e2ee-metadata': rawMetadata,
-			'e2ee-metadata-signature': metadataSignature,
-		} = stat.props! as Record<string, string>
-		if (fileId && rawMetadata && metadataSignature) {
-			await metadataStore.setRawMetadata(
-				path,
-				fileId,
-				rawMetadata,
-				metadataSignature,
-			)
-		}
-
-		const metadata = await metadataStore.getMetadata(path)
-
-		if (metadata.metadata instanceof RootMetadata) {
-			replacePlaceholdersInPropfind(xml, path, metadata.metadata)
-		} else {
-			const { metadata: parentMetadata } = await metadataStore.getMetadata(dirname(metadata.path))
-			replacePlaceholdersInPropfind(xml, path, metadata.metadata, parentMetadata)
-		}
-	} else if (stat.type === 'file') {
-		const { metadata, path: parentPath } = await metadataStore.getMetadata(dirname(path))
-		replacePlaceholdersInPropfind(xml, parentPath, metadata)
-	}
+	await cacheMetadataFromPropfind(xml, isEncryptedNode)
+	await replacePlaceholdersInPropfind(xml, isEncryptedNode)
 
 	context.res = new Response(new XMLBuilder().build(xml), response)
 }
 
 /**
+ * Cache all e2ee metadata that is shipped as part of the PROPFIND response.
+ *
  * @param xml - The XML response
- * @param path - The path of the file or folder
- * @param metadata - The metadata for the file or folder
- * @param parentMetadata - The metadata for the parent folder
+ * @param isEncryptedNode - Whether a given response node is end-to-end encrypted
  */
-function replacePlaceholdersInPropfind(xml: DAVResult, path: string, metadata: Metadata, parentMetadata?: Metadata): void {
-	logger.debug('Updating PROPFIND info', { path, metadata, parentMetadata, xml })
-
-	const parsedNodes: DAVResultResponse[] = []
-	for (const childNode of xml.multistatus.response) {
-		if (childNode.propstat === undefined) {
-			throw new Error('Invalid PROPFIND response: missing propstat')
-		}
-
-		if (childNode.propstat.prop.permissions) {
-			// remove share permissions as we have internal sharing methods for e2ee
-			childNode.propstat.prop.permissions = (childNode.propstat.prop.permissions as string).replace(/R/g, '')
-		}
-
-		const currentMetadata = depths(childNode.href) <= depths(path) ? parentMetadata : metadata
-		if (!currentMetadata) {
-			logger.debug('No current metadata found, skipping PROPFIND replacement (likely the e2ee root)', { path, childNode, metadata, parentMetadata })
-			parsedNodes.push(childNode)
+async function cacheMetadataFromPropfind(xml: DAVResult, isEncryptedNode: (node: DAVResultResponse) => boolean): Promise<void> {
+	for (const node of xml.multistatus.response) {
+		if (!isEncryptedNode(node) || node.propstat === undefined) {
 			continue
 		}
 
-		const identifier = childNode.propstat.prop.displayname
-		const isFolder = typeof childNode.propstat.prop?.resourcetype.collection !== 'undefined'
+		const isFolder = typeof node.propstat.prop?.resourcetype.collection !== 'undefined'
+		const {
+			fileid: fileId,
+			'e2ee-metadata': rawMetadata,
+			'e2ee-metadata-signature': metadataSignature,
+		} = node.propstat.prop as Record<string, string>
+		if (isFolder && fileId && rawMetadata && metadataSignature) {
+			await metadataStore.setRawMetadata(
+				nodePath(node),
+				fileId,
+				rawMetadata,
+				metadataSignature,
+			)
+		}
+	}
+}
+
+/**
+ * Replace the encrypted placeholder names and mimetypes of all encrypted nodes
+ * with the real ones from the metadata of their parent folder.
+ *
+ * @param xml - The XML response
+ * @param isEncryptedNode - Whether a given response node is end-to-end encrypted
+ */
+async function replacePlaceholdersInPropfind(xml: DAVResult, isEncryptedNode: (node: DAVResultResponse) => boolean): Promise<void> {
+	logger.debug('Updating PROPFIND info', { xml })
+
+	// Encryption state of all nodes in the response - used to look up whether the parent of a node is encrypted.
+	const encryptedPaths = new Map<string, boolean>()
+	for (const node of xml.multistatus.response) {
+		encryptedPaths.set(nodePath(node), isEncryptedNode(node))
+	}
+
+	const parsedNodes: DAVResultResponse[] = []
+	for (const node of xml.multistatus.response) {
+		if (!isEncryptedNode(node)) {
+			// e.g. an unencrypted sibling of an e2ee root - keep it untouched
+			parsedNodes.push(node)
+			continue
+		}
+
+		if (node.propstat === undefined) {
+			throw new Error('Invalid PROPFIND response: missing propstat')
+		}
+
+		if (node.propstat.prop.permissions) {
+			// remove share permissions as we have internal sharing methods for e2ee
+			node.propstat.prop.permissions = (node.propstat.prop.permissions as string).replace(/R/g, '')
+		}
+
+		const isFolder = typeof node.propstat.prop?.resourcetype.collection !== 'undefined'
+		if (!(await hasEncryptedParent(node, isFolder, encryptedPaths))) {
+			// The node is an e2ee root: its name is not encrypted so only the permissions needed adjustment.
+			logger.debug('Node is an e2ee root, skipping PROPFIND replacement', { node })
+			parsedNodes.push(node)
+			continue
+		}
+
+		const { metadata, path: parentPath } = await metadataStore.getMetadata(dirname(nodePath(node)))
+		const identifier = node.propstat.prop.displayname
 		if (isFolder) {
-			const name = currentMetadata.getFolder(identifier)
+			const name = metadata.getFolder(identifier)
 			if (!name) {
-				logger.error('Could not find folder in metadata for PROPFIND replacement', { path, childNode, identifier, currentMetadata })
+				logger.error('Could not find folder in metadata for PROPFIND replacement', { node, identifier, metadata })
 				continue
 			}
 
-			childNode.propstat.prop.displayname = name
-			childNode.propstat.prop.getcontenttype = 'httpd/unix-directory'
+			node.propstat.prop.displayname = name
+			node.propstat.prop.getcontenttype = 'httpd/unix-directory'
 		} else {
-			const info = currentMetadata.getFile(identifier)
+			const info = metadata.getFile(identifier)
 			if (!info) {
-				if (currentMetadata instanceof RootMetadata && currentMetadata.fileDropEntries.includes(identifier)) {
-					logger.debug('File drop entry found for PROPFIND replacement', { path, childNode, identifier })
-					if (childNode.propstat.prop.permissions && (childNode.propstat.prop.permissions as string).includes('NV')) {
+				if (metadata instanceof RootMetadata && metadata.fileDropEntries.includes(identifier)) {
+					logger.debug('File drop entry found for PROPFIND replacement', { node, identifier })
+					if (node.propstat.prop.permissions && (node.propstat.prop.permissions as string).includes('NV')) {
 						// we found a file drop entry and we have permissions to migrate it
 						// so we do not want to block this request any longer but we should
 						// notify the user that this entry needs migration
-						taskStore.addFileDropMigration(path)
+						taskStore.addFileDropMigration(parentPath)
 					}
 
 					continue
 				}
 
-				logger.error('Could not find file in metadata for PROPFIND replacement', { path, childNode, identifier, currentMetadata })
+				logger.error('Could not find file in metadata for PROPFIND replacement', { node, identifier, metadata })
 				continue
 			}
 
-			childNode.propstat.prop.displayname = info.filename
-			childNode.propstat.prop.getcontenttype = info.mimetype
+			node.propstat.prop.displayname = info.filename
+			node.propstat.prop.getcontenttype = info.mimetype
 		}
-		parsedNodes.push(childNode)
+		parsedNodes.push(node)
 	}
 	xml.multistatus.response = parsedNodes
 }
 
 /**
- * Checks the depth of a folder path.
+ * Check whether the parent folder of the given node is encrypted,
+ * meaning the name of the node is a placeholder that needs to be replaced.
+ * If the parent is not encrypted the node itself is an e2ee root.
  *
- * @param folder - The folder path
+ * @param node - The response node to check
+ * @param isFolder - Whether the node is a folder
+ * @param encryptedPaths - Encryption state of all nodes in the response
  */
-function depths(folder: string): number {
-	return folder
-		.split('/')
-		.filter(Boolean)
-		.length
+async function hasEncryptedParent(node: DAVResultResponse, isFolder: boolean, encryptedPaths: Map<string, boolean>): Promise<boolean> {
+	const parentState = encryptedPaths.get(dirname(nodePath(node)))
+	if (parentState !== undefined) {
+		return parentState
+	}
+
+	// The parent is not part of the response, so this node is the PROPFIND target itself.
+	if (!isFolder) {
+		// an encrypted file is always located inside an encrypted folder
+		return true
+	}
+
+	// Only an e2ee root has root metadata, every other encrypted folder has an encrypted parent.
+	const { metadata } = await metadataStore.getMetadata(nodePath(node))
+	return !(metadata instanceof RootMetadata)
+}
+
+/**
+ * Get the path of a response node (its href without trailing slash).
+ *
+ * @param node - The response node
+ */
+function nodePath(node: DAVResultResponse): string {
+	return node.href.replace(/\/+$/, '')
 }


### PR DESCRIPTION
- resolves https://github.com/nextcloud/end_to_end_encryption/issues/1735

e.g. on the root the PROPFIND root is unencrypted - before this the whole PROPFIND would be ignored - but we still need to check the child nodes for e2ee and adjust the results if needed.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
