### PR TITLE
fix(filedrop): properly handle rejected files

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -500,7 +500,7 @@ export async function searchFolders(path: string) {
  * @param fileId - The fileid of the e2ee root folder to add the entries to
  * @param shareToken - The share token of the public share the folder belongs to
  */
-export async function addFileDrop(fileDropEntries: { [key: string]: IRawMetadataFileDrop }, fileId: string, shareToken?: string): Promise<{ [key: string]: IRawMetadataFileDrop }> {
+export async function addFileDrop(fileDropEntries: { [key: string]: IRawMetadataFileDrop }, fileId: string, shareToken?: string): Promise<null | string[]> {
 	const url = generateOcsUrl(Url.FileDrop, { fileId })
 
 	const response = await axios.put<OCSResponse<{ filedrop: { [key: string]: IRawMetadataFileDrop } }>>(
@@ -516,9 +516,12 @@ export async function addFileDrop(fileDropEntries: { [key: string]: IRawMetadata
 		},
 	)
 
-	if (response.data.ocs.meta.statuscode !== 200) {
-		throw new Error(`Failed to upload metadata: ${response.data.ocs.meta.message}`)
+	if (response.status === 202) {
+		return null // The server is still processing the request, the client should retry later
+	} else if (response.status !== 200 || response.data.ocs.meta.statuscode !== 200) {
+		const message = response.data?.ocs?.meta?.message
+		throw new Error('Failed to upload metadata' + (message ? `: ${message}` : ''))
 	}
 
-	return response.data.ocs.data.filedrop
+	return Object.keys(response.data.ocs.data.filedrop)
 }

--- a/src/services/fileDropUtils.ts
+++ b/src/services/fileDropUtils.ts
@@ -3,6 +3,8 @@
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  */
 
+import type { IRawMetadataFileDrop } from '../models/metadata.d.ts'
+
 import { getCapabilities } from '@nextcloud/capabilities'
 import { getClient, getRemoteURL, getRootPath } from '@nextcloud/files/dav'
 import { join } from '@nextcloud/paths'
@@ -24,7 +26,7 @@ const client = getClient(getRemoteURL())
  * @param shareToken - The share token of the public share to upload the file to
  * @param users - Mapping of user IDs to their public keys to encrypt the file drop entry for
  */
-export async function uploadFileDrop(unencryptedFile: File, fileId: string, shareToken: string, users: { userId: string, key: CryptoKey }[]): Promise<void> {
+export async function uploadFileDrop(unencryptedFile: File, fileId: string, shareToken: string, users: { userId: string, key: CryptoKey }[]): Promise<[string, IRawMetadataFileDrop]> {
 	const key = await generateAESKey()
 	const encryptedFileName = generateUuid()
 
@@ -43,7 +45,18 @@ export async function uploadFileDrop(unencryptedFile: File, fileId: string, shar
 	})
 
 	const rawEntry = await fileDropEntry.export(users)
-	await api.addFileDrop({ [encryptedFileName]: rawEntry }, fileId, shareToken)
+	return [encryptedFileName, rawEntry]
+}
+
+/**
+ * Finalize the file drop by uploading the metadata entries.
+ *
+ * @param entries - The entries to upload
+ * @param fileId - The id of the file drop folder to add the entries to
+ * @param shareToken - The current share token of the public share to upload the entries to
+ */
+export async function finalizeFileDrop(entries: Record<string, IRawMetadataFileDrop>, fileId: string, shareToken: string): Promise<null | string[]> {
+	return await api.addFileDrop(entries, fileId, shareToken)
 }
 
 /**

--- a/src/views/FileDrop.vue
+++ b/src/views/FileDrop.vue
@@ -4,7 +4,10 @@
 -->
 
 <script setup lang="ts">
+import type { IRawMetadataFileDrop } from '../models/metadata.d.ts'
+
 import { mdiAlertCircleOutline, mdiCheck } from '@mdi/js'
+import { showInfo, showWarning } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
 import { getSharingToken } from '@nextcloud/sharing/public'
@@ -15,7 +18,7 @@ import NcContent from '@nextcloud/vue/components/NcContent'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
-import { uploadFileDrop } from '../services/fileDropUtils.ts'
+import { finalizeFileDrop, uploadFileDrop } from '../services/fileDropUtils.ts'
 import logger from '../services/logger.ts'
 
 const folderId = loadState<string>('end_to_end_encryption', 'fileId')
@@ -86,15 +89,22 @@ async function handleUpload(fileList: FileList) {
 		return
 	}
 
+	// clear the list of uploaded files
+	uploadedFiles.value = []
+
 	loading.value = true
-	const promises: Promise<void>[] = []
+	const promises: Promise<[string, IRawMetadataFileDrop]>[] = []
+	const fileNames: string[] = []
 	logger.debug('[FileDrop] Starting upload of files')
 	for (const file of Array.from(fileList)) {
+		fileNames.push(file.name)
+
 		const entry = reactive({ name: file.name, status: 'uploading' as 'uploading' | 'done' | 'error' })
 		uploadedFiles.value.push(entry)
 		promises.push(uploadFileDrop(file, folderId, getSharingToken()!, publicKeys)
-			.then(() => {
+			.then((entries) => {
 				entry.status = 'done'
+				return entries
 			})
 			.catch((error) => {
 				entry.status = 'error'
@@ -104,8 +114,25 @@ async function handleUpload(fileList: FileList) {
 
 	logger.debug('[FileDrop] Waiting for all files to be encrypted and uploaded')
 	try {
-		await Promise.all(promises)
-		logger.debug('[FileDrop] All files encrypted and uploaded')
+		const allEntries = await Promise.all(promises)
+		const result = await finalizeFileDrop(Object.fromEntries(allEntries), folderId, getSharingToken()!)
+		if (result === null) {
+			logger.debug('[FileDrop] Server is still processing the request')
+			showInfo(t('end_to_end_encryption', 'The upload completed, but the file drop is still being processed on the server.'))
+		} else if (result.length < fileNames.length) {
+			const failedFiles: string[] = []
+			for (const [name] of allEntries) {
+				if (!result.includes(name)) {
+					const index = allEntries.findIndex(([encryptedFileName]) => encryptedFileName === name)
+					failedFiles.push(fileNames[index])
+					logger.debug(`[FileDrop] File ${failedFiles.at(-1)} failed to upload`)
+					uploadedFiles.value[index].status = 'error'
+				}
+			}
+			showWarning(t('end_to_end_encryption', 'Some files failed to upload.'))
+		} else {
+			logger.debug('[FileDrop] All files encrypted and uploaded')
+		}
 	} catch (exception) {
 		logger.error('[FileDrop] Error while encrypting and uploading files', { exception })
 	}

--- a/tests/Unit/BackgroundJob/RollbackBackgroundJobTest.php
+++ b/tests/Unit/BackgroundJob/RollbackBackgroundJobTest.php
@@ -13,7 +13,6 @@ use OCA\EndToEndEncryption\RollbackService;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class RollbackBackgroundJobTest extends TestCase {


### PR DESCRIPTION
If the API returns less entries than requested we need to mark them as failed. Moreover this fixes a problem where a race condition could lead to unexpected behavior because every uploaded file (drag and drop allows multiple) was adding its own metadata entry.
This is not handled in one batch to the metadata API.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
