### PR TITLE
fix(web): properly handle DELETE requests

### DIFF
--- a/src/middleware/useDeleteInterceptor.spec.ts
+++ b/src/middleware/useDeleteInterceptor.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { IMetadataFile } from '../models/metadata.d.ts'
+
+import { X509Certificate } from '@peculiar/x509'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+	adminMnemonic,
+	adminPrivateKeyInfo,
+	rootFolderMetadata,
+} from '../../__tests__/consts.spec.ts'
+import { Metadata } from '../models/Metadata.ts'
+import { RootMetadata } from '../models/RootMetadata.ts'
+import * as api from '../services/api.ts'
+import { decryptPrivateKey } from '../services/privateKeyUtils.ts'
+import * as metadataStore from '../store/metadata.ts'
+import { useDeleteInterceptor } from './useDeleteInterceptor.ts'
+
+vi.mock('@nextcloud/auth', () => ({ getCurrentUser: () => ({ uid: 'admin' }) }))
+vi.mock('@nextcloud/sharing/public', () => ({
+	isPublicShare: () => false,
+	getSharingToken: () => null,
+}))
+vi.mock('../store/keys.ts', () => ({
+	getCertificate: async () => {
+		const certificate = new X509Certificate(rootFolderMetadata.users[1]!.certificate)
+		certificate.privateKey = await decryptPrivateKey(adminPrivateKeyInfo, adminMnemonic)
+		return certificate
+	},
+	getPrivateKey: async () => await decryptPrivateKey(adminPrivateKeyInfo, adminMnemonic),
+	loadPrivateKey: async () => true,
+	loadPublicKey: async () => true,
+}))
+vi.mock('../services/api.ts', { spy: true })
+
+/** The e2ee root folder, as shipped by the metadata fixture */
+const ROOT = '/remote.php/dav/files/admin/New folder'
+/** A file within the e2ee root folder */
+const FILE_UUID = 'ad3b12554e0d4364854ae3e21b170152'
+/** A folder within the e2ee root folder */
+const SUB_UUID = 'fa666d819a6c4315abba421172f0a0b1'
+/** The counter of the metadata fixture */
+const COUNTER = 5
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	vi.mocked(api.lockFolder).mockResolvedValue('lock-token')
+	vi.mocked(api.unlockFolder).mockResolvedValue()
+	vi.mocked(api.updateMetadata).mockResolvedValue()
+	vi.mocked(api.deleteMetadata).mockResolvedValue()
+	// only folders have metadata of their own, and only within the e2ee root folder.
+	// Folders are seeded into the cache, so every uuid that gets here is a file.
+	vi.mocked(api.getMetadataByPath).mockImplementation(async (path: string) => {
+		if (/\/New folder(\/[0-9a-f]{32})+$/.test(path)) {
+			return false
+		}
+		throw new api.NoMetadataError(`No metadata found for path ${path}`)
+	})
+	metadataStore.deleteMetadata(ROOT)
+})
+
+describe('pass through', () => {
+	test('passes through targets that are not end-to-end encrypted', async () => {
+		const { next } = await runDelete('/remote.php/dav/files/admin/unencrypted/file.txt')
+
+		expect(next).toHaveBeenCalledOnce()
+		expect(api.lockFolder).not.toHaveBeenCalled()
+	})
+
+	test('does not pass through when the metadata could not be read', async () => {
+		vi.mocked(api.getMetadataByPath).mockRejectedValue(new Error('Signature verification failed'))
+
+		await expect(runDelete(`${ROOT}/${FILE_UUID}`)).rejects.toThrow('Signature verification failed')
+		expect(api.lockFolder).not.toHaveBeenCalled()
+	})
+})
+
+describe('deleting a file', () => {
+	test('removes a file of the e2ee root folder from its metadata', async () => {
+		const metadata = await seedRootFolder()
+		const markAsDeleted = vi.spyOn(metadata, 'markAsDeleted')
+
+		const { context, next } = await runDelete(`${ROOT}/${FILE_UUID}`)
+
+		// the file is removed, but the folder itself is left alone
+		expect(markAsDeleted).not.toHaveBeenCalled()
+		expect(metadata.listContents()).toEqual(['Test'])
+		// within the lock of the parent, using the next counter
+		expect(api.lockFolder).toHaveBeenCalledExactlyOnceWith('89', COUNTER + 1)
+		expect(api.updateMetadata).toHaveBeenCalledOnce()
+		expect(api.unlockFolder).toHaveBeenCalledExactlyOnceWith('89', 'lock-token')
+		// and the request itself was authorized and kept out of the trashbin
+		expect(next).toHaveBeenCalledOnce()
+		expect(context.req.headers.get('E2E-TOKEN')).toBe('lock-token')
+		expect(context.req.headers.get('X-E2EE-SUPPORTED')).toBe('true')
+		expect(context.req.headers.get('X-NC-Skip-Trashbin')).toBe('true')
+	})
+
+	test('removes a file of a subfolder from its metadata', async () => {
+		const root = await seedRootFolder()
+		const metadata = await seedSubFolder(root.key)
+		metadata.addFile(FILE_UUID, file('test.txt'))
+		await metadata.export(await (await import('../store/keys.ts')).getCertificate())
+
+		await runDelete(`${ROOT}/${SUB_UUID}/${FILE_UUID}`)
+
+		expect(metadata.listContents()).toEqual([])
+		// the metadata of the subfolder is updated - it was exported once while
+		// seeding the file, so its counter is at 1 - and the root folder is untouched
+		expect(api.lockFolder).toHaveBeenCalledExactlyOnceWith('90', 2)
+		expect(root.listContents()).toEqual(['Test', 'test.txt'])
+	})
+
+	test('deleting one file does not break the next one', async () => {
+		const metadata = await seedRootFolder()
+		metadata.addFile('bbbb12554e0d4364854ae3e21b170152', file('second.txt'))
+		await metadata.export(await (await import('../store/keys.ts')).getCertificate())
+
+		await runDelete(`${ROOT}/${FILE_UUID}`)
+		await runDelete(`${ROOT}/bbbb12554e0d4364854ae3e21b170152`)
+
+		expect(metadata.listContents()).toEqual(['Test'])
+		// the counter of the metadata is bumped once per delete, the lock has to match it
+		expect(vi.mocked(api.lockFolder).mock.calls.map(([, counter]) => counter))
+			.toEqual([COUNTER + 2, COUNTER + 3])
+		expect(metadata.counter).toBe(COUNTER + 3)
+		expect(api.updateMetadata).toHaveBeenCalledTimes(2)
+	})
+})
+
+describe('deleting a folder', () => {
+	test('marks the metadata of the e2ee root folder as deleted', async () => {
+		const metadata = await seedRootFolder()
+		const markAsDeleted = vi.spyOn(metadata, 'markAsDeleted')
+
+		const { context, next } = await runDelete(ROOT)
+
+		expect(markAsDeleted).toHaveBeenCalledOnce()
+		// the metadata of the folder itself is updated, it has no parent to update
+		expect(api.lockFolder).toHaveBeenCalledExactlyOnceWith('89', COUNTER + 1)
+		expect(api.updateMetadata).toHaveBeenCalledOnce()
+		expect(api.deleteMetadata).not.toHaveBeenCalled()
+		expect(next).toHaveBeenCalledOnce()
+		expect(context.req.headers.get('E2E-TOKEN')).toBe('lock-token')
+	})
+
+	test('removes a subfolder from the metadata of its parent', async () => {
+		const root = await seedRootFolder()
+		await seedSubFolder(root.key)
+
+		const { next } = await runDelete(`${ROOT}/${SUB_UUID}`)
+
+		expect(root.listContents()).toEqual(['test.txt'])
+		// the metadata of the deleted folder is removed within the lock of the parent
+		expect(api.lockFolder).toHaveBeenCalledExactlyOnceWith('89', COUNTER + 1)
+		expect(api.deleteMetadata).toHaveBeenCalledExactlyOnceWith('90', 'lock-token')
+		expect(api.updateMetadata).toHaveBeenCalledOnce()
+		expect(next).toHaveBeenCalledOnce()
+	})
+})
+
+/**
+ * Seed the cache with the metadata of the e2ee root folder, like a PROPFIND would.
+ */
+async function seedRootFolder(): Promise<RootMetadata> {
+	const privateKey = await decryptPrivateKey(adminPrivateKeyInfo, adminMnemonic)
+	const metadata = await RootMetadata.fromJson(rootFolderMetadata, 'admin', privateKey)
+	metadataStore.setMetadata(ROOT, '89', metadata)
+	return metadata
+}
+
+/**
+ * Seed the cache with the metadata of the subfolder of the e2ee root folder.
+ *
+ * @param key - The metadata key of the e2ee root folder
+ */
+async function seedSubFolder(key: CryptoKey): Promise<Metadata> {
+	const metadata = await Metadata.createNew(key)
+	metadataStore.setMetadata(`${ROOT}/${SUB_UUID}`, '90', metadata)
+	return metadata
+}
+
+/**
+ * Run the DELETE interceptor for the given path.
+ *
+ * @param path - The path of the node to delete
+ */
+async function runDelete(path: string) {
+	const next = vi.fn(async () => {})
+	const context = {
+		req: new Request(`https://example.com${path}`, { method: 'DELETE' }),
+		res: new Response(),
+		type: 'fetch' as const,
+	}
+	await useDeleteInterceptor(context, next)
+	return { context, next }
+}
+
+/**
+ * A metadata file entry.
+ *
+ * @param filename - The name of the file
+ */
+function file(filename: string): IMetadataFile {
+	return {
+		filename,
+		mimetype: 'text/plain',
+		key: 'Hj+q7e53ZeQdHKPyF7FKeg==',
+		nonce: 'sqqtY0eRjhuwf+qTv5Kg2g==',
+		authenticationTag: 'nJHAcpZwSS1BCIkGbmtbNg==',
+	}
+}

--- a/src/middleware/useDeleteInterceptor.ts
+++ b/src/middleware/useDeleteInterceptor.ts
@@ -10,7 +10,7 @@ import stringify from 'safe-stable-stringify'
 import { RootMetadata } from '../models/RootMetadata.ts'
 import * as api from '../services/api.ts'
 import logger from '../services/logger.ts'
-import { decodePath } from '../services/path.ts'
+import { getPath } from '../services/path.ts'
 import * as keyStore from '../store/keys.ts'
 import * as metadataStore from '../store/metadata.ts'
 
@@ -27,16 +27,22 @@ import * as metadataStore from '../store/metadata.ts'
 export async function useDeleteInterceptor(context: FetchContext, next: () => Promise<void>): Promise<void> {
 	logger.debug('Handling DELETE request', { request: context.req })
 
-	// the metadata knows the target by its decoded path, the request URL carries it encoded
-	const path = decodePath(new URL(context.req.url).pathname)
+	// the metadata knows the target by its decoded path relative to the DAV root,
+	// the request URL carries it encoded and absolute
+	const path = getPath(new URL(context.req.url))
 	let isRootFolder: boolean
 	try {
-		const { metadata } = await metadataStore.getMetadata(path)
-		isRootFolder = metadata instanceof RootMetadata
+		const { metadata, path: metadataPath } = await metadataStore.getMetadata(path)
+		// only the e2ee root folder has root metadata of its own - for the files
+		// directly inside it the very same metadata is the one of their parent
+		isRootFolder = metadata instanceof RootMetadata && path === metadataPath
 	} catch (error) {
-		logger.debug('Could not get root metadata for DELETE', { error })
-		// not end-to-end encrypted
-		return next()
+		if (error instanceof api.NoMetadataError) {
+			logger.debug('Could not get root metadata for DELETE', { error })
+			// not end-to-end encrypted
+			return next()
+		}
+		throw error
 	}
 
 	context.req.headers.set('X-E2EE-SUPPORTED', 'true')
@@ -85,6 +91,7 @@ async function handleDeleteRoot(path: string, context: FetchContext, next: () =>
 		)
 
 		// now the proper delete
+		context.req.headers.set('X-NC-Skip-Trashbin', 'true')
 		context.req.headers.set('X-E2EE-SUPPORTED', 'true')
 		context.req.headers.set('E2E-TOKEN', lockToken)
 		await next()

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -20,6 +20,12 @@ import logger from './logger.ts'
 
 addPasswordConfirmationInterceptors(axios)
 
+/**
+ * Error thrown when no metadata is found for a given path.
+ */
+export class NoMetadataError extends Error {
+}
+
 // API: https://github.com/nextcloud/end_to_end_encryption/blob/main/doc/api.md
 
 const API_ROOT = 'apps/end_to_end_encryption/api/v2'
@@ -377,14 +383,14 @@ interface MetdataResponse {
  *
  * @param path - The file path of the folder relative to the DAV root
  * @return The metadata response or false if the path is not a folder
- * @throws {Error} If metadata could not be fetched, is not available or incomplete
+ * @throws {NoMetadataError} If metadata could not be fetched, is not available or incomplete
  */
 export async function getMetadataByPath(path: string): Promise<MetdataResponse | false> {
 	const result = await getNodeStat(path)
 
 	if (!result.props) {
 		logger.debug('No props found in PROPFIND result', { result, path })
-		throw new Error('No metadata found for path ' + path)
+		throw new NoMetadataError('No metadata found for path ' + path)
 	}
 
 	const isFolder = typeof result.props.resourcetype.collection !== 'undefined'
@@ -399,7 +405,7 @@ export async function getMetadataByPath(path: string): Promise<MetdataResponse |
 	} = result.props
 	if (!fileId || !metadata || !signature) {
 		logger.debug('Not all props provided by PROPFIND', { path, fileId, metadata, signature })
-		throw new Error('No metadata found for path ' + path)
+		throw new NoMetadataError('No metadata found for path ' + path)
 	}
 
 	return {

--- a/src/store/metadata.ts
+++ b/src/store/metadata.ts
@@ -20,7 +20,9 @@ export interface IStoreMetadata {
 	id: string
 	/** The metadata itself */
 	metadata: Metadata
-	/** The path of the metadata */
+	/**
+	 * The path of the folder the metadata belongs to.
+	 */
 	path: string
 }
 
@@ -32,7 +34,7 @@ export interface IStoreMetadata {
  * of a PROPFIND response or as the name of a node. `decodePath` is what turns
  * the former two into that.
  */
-const metadataCache = new Map<string, Omit<IStoreMetadata, 'path'>>()
+const metadataCache = new Map<string, IStoreMetadata>()
 const currentUser = isPublicShare()
 	? `s:${getSharingToken()}`
 	: getCurrentUser()!.uid
@@ -43,11 +45,12 @@ const currentUser = isPublicShare()
  * @param metadata - The root metadata
  */
 export function getRootFolder(metadata: RootMetadata): IStoreMetadata & { metadata: RootMetadata } {
-	const entry = metadataCache.entries().find(([, { metadata: md }]) => md === metadata)!
+	// any entry pointing to this metadata knows the path of the folder it belongs to,
+	// so it does not matter whether the folder itself or one of its files is found
+	const entry = metadataCache.values().find(({ metadata: md }) => md === metadata)!
 	return {
-		id: entry[1].id,
-		metadata: entry[1].metadata as RootMetadata,
-		path: entry[0],
+		...entry,
+		metadata: entry.metadata as RootMetadata,
 	}
 }
 
@@ -56,7 +59,7 @@ export function getRootFolder(metadata: RootMetadata): IStoreMetadata & { metada
  *
  * @param path - The path to get the root metadata for
  * @throws {Error} - If the root metadata signature verification fails
- * @throws {AxiosError} - If the target path is not end-to-end encrypted
+ * @throws {NoMetadataError} - If the target path is not end-to-end encrypted
  */
 export async function getRootMetadata(path: string): Promise<RootMetadata> {
 	path = normalizePath(path)
@@ -73,8 +76,9 @@ export async function getRootMetadata(path: string): Promise<RootMetadata> {
 	if (data === false) {
 		// its a file so get its parent metadata
 		const root = await getRootMetadata(dirname(path))
-		const { metadata, id } = await getMetadata(dirname(path))
-		setMetadata(path, id, metadata)
+		const { id, metadata } = await getMetadata(dirname(path))
+		// the file is an entry of its parent metadata, it has none of its own
+		setMetadata(path, id, metadata, dirname(path))
 		return root
 	}
 
@@ -103,27 +107,26 @@ export async function getMetadata(path: string): Promise<IStoreMetadata> {
 		await getRootMetadata(path)
 	}
 
-	return {
-		...metadataCache.get(path)!,
-		path,
-	}
+	return { ...metadataCache.get(path)! }
 }
 
 /**
  * Set the metadata for the given path.
  *
- * @param path - The path of the metadata
+ * @param path - The path to cache the metadata for
  * @param id - The file id of the metadata
  * @param metadata - The metadata object
+ * @param ownerPath - The path of the folder the metadata belongs to, if that is not `path` itself (see `IStoreMetadata.path`)
  */
-export function setMetadata(path: string, id: string, metadata: Metadata): IStoreMetadata {
+export function setMetadata(path: string, id: string, metadata: Metadata, ownerPath: string = path): IStoreMetadata {
 	path = normalizePath(path)
-	metadataCache.set(path, { id, metadata })
-	return {
+	const entry = {
 		id,
 		metadata,
-		path,
+		path: normalizePath(ownerPath),
 	}
+	metadataCache.set(path, entry)
+	return { ...entry }
 }
 
 /**


### PR DESCRIPTION
We need to compare the path of the metadata to the DELETE request path, otherwise we might accidentially consider a DELETE of a file inside the root encrypted folder as a delete of the root.

This fixes a problem where e.g. DELETE `encrypted/foo.txt` would cause the metadata to be corrupted.

I have adjusted the code to store the path of the **metadata** in the store, before we just had a look-up table for path -> metadata where path also was used for files as a cache.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
