### PR TITLE
test: add end-to-end test for deleting files

### DIFF
--- a/tests/playwright/e2e/delete-file.spec.ts
+++ b/tests/playwright/e2e/delete-file.spec.ts
@@ -1,0 +1,76 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect } from '@playwright/test'
+import { test } from '../support/fixtures/encrypted-folder.ts'
+import { createFolderInEncryptedFolder, uploadFileToEncryptedFolder, withEncryptedFolderUpdate } from '../support/utils/e2ee.ts'
+import { disableDefaultHomeContents } from '../support/utils/occ.ts'
+
+/**
+ * Deleting a file only removes its entry from the metadata of the folder it is
+ * in - the folder itself has to survive untouched. Every test therefore keeps a
+ * sibling around and decrypts the folder from scratch afterwards: a listing that
+ * still has the sibling is the proof that the metadata was rewritten correctly
+ * and not, say, emptied or marked as deleted.
+ */
+test.describe('deleting files in encrypted folders', () => {
+	test.beforeAll(disableDefaultHomeContents)
+
+	test('delete a file', async ({ filesApp, page, mnemonic, encryptedFolder }) => {
+		await uploadFileToEncryptedFolder(page, filesApp, 'kept-file.txt')
+		await uploadFileToEncryptedFolder(page, filesApp, 'deleted-file.txt')
+
+		await withEncryptedFolderUpdate(page, () => filesApp.deleteFileOrFolder('deleted-file.txt'))
+
+		// gone from the list, and the sibling untouched
+		await expect(filesApp.getFileOrFolder('deleted-file.txt')).toHaveCount(0)
+		await expect(filesApp.getFileOrFolder('kept-file.txt')).toBeVisible()
+
+		// still gone once the folder is decrypted from scratch
+		await filesApp.reopenEncryptedFolder(encryptedFolder, mnemonic)
+		await expect(filesApp.getFileOrFolder('kept-file.txt')).toBeVisible()
+		await expect(filesApp.getFileOrFolder('deleted-file.txt')).toHaveCount(0)
+	})
+
+	test('delete a file in a nested folder', async ({ filesApp, page, mnemonic, encryptedFolder }) => {
+		await createFolderInEncryptedFolder(page, filesApp, 'nested-folder')
+		await filesApp.openFolder('nested-folder')
+
+		await uploadFileToEncryptedFolder(page, filesApp, 'kept-file.txt')
+		await uploadFileToEncryptedFolder(page, filesApp, 'deleted-file.txt')
+
+		await withEncryptedFolderUpdate(page, () => filesApp.deleteFileOrFolder('deleted-file.txt'))
+
+		await expect(filesApp.getFileOrFolder('deleted-file.txt')).toHaveCount(0)
+		await expect(filesApp.getFileOrFolder('kept-file.txt')).toBeVisible()
+
+		// the nested folder is only reachable through its parent, so this asserts
+		// that the metadata of both of them survived
+		await filesApp.reopenEncryptedFolder(encryptedFolder, mnemonic)
+		await filesApp.openFolder('nested-folder')
+		await expect(filesApp.getFileOrFolder('kept-file.txt')).toBeVisible()
+		await expect(filesApp.getFileOrFolder('deleted-file.txt')).toHaveCount(0)
+	})
+
+	test('delete two files in sequence', async ({ filesApp, page, mnemonic, encryptedFolder }) => {
+		for (const name of ['kept-file.txt', 'first-file.txt', 'second-file.txt']) {
+			await uploadFileToEncryptedFolder(page, filesApp, name)
+		}
+
+		// The second delete is the point of this test: it has to find the folder in
+		// the state the first one left it in - both in the metadata on the server and
+		// in what the app kept in memory - which is what deleting the second file
+		// through the same page load exercises.
+		await withEncryptedFolderUpdate(page, () => filesApp.deleteFileOrFolder('first-file.txt'))
+		await withEncryptedFolderUpdate(page, () => filesApp.deleteFileOrFolder('second-file.txt'))
+
+		await expect(filesApp.getFileOrFolder('kept-file.txt')).toBeVisible()
+
+		await filesApp.reopenEncryptedFolder(encryptedFolder, mnemonic)
+		await expect(filesApp.getFileOrFolder('kept-file.txt')).toBeVisible()
+		await expect(filesApp.getFileOrFolder('first-file.txt')).toHaveCount(0)
+		await expect(filesApp.getFileOrFolder('second-file.txt')).toHaveCount(0)
+	})
+})

--- a/tests/playwright/support/sections/FilesAppPage.ts
+++ b/tests/playwright/support/sections/FilesAppPage.ts
@@ -104,6 +104,32 @@ export class FilesAppPage {
 			.click()
 	}
 
+	/**
+	 * Navigate into a folder and wait until its contents are rendered.
+	 *
+	 * @param name - Name of the folder to open
+	 */
+	public async openFolder(name: string): Promise<void> {
+		await this.openFileOrFolder(name)
+		await this.waitForListLoaded()
+	}
+
+	/**
+	 * Upload a text file into the current folder and wait for its row to appear.
+	 *
+	 * Note that inside an encrypted folder this returns while the parent metadata
+	 * is still being rewritten - wrap the call in `withEncryptedFolderUpdate` to
+	 * await that too, or use `uploadFileToEncryptedFolder`.
+	 *
+	 * @param name - Name of the file to create
+	 * @param content - Contents of the file
+	 */
+	public async uploadTextFile(name: string, content: string = `content of ${name}\n`): Promise<void> {
+		const newMenu = await this.openNewMenu()
+		await newMenu.uploadFiles({ name, mimeType: 'text/plain', buffer: Buffer.from(content) })
+		await expect(this.getFileOrFolder(name)).toBeVisible()
+	}
+
 	public getMnemonicDialog(): SectionMnemonicDialog {
 		return new SectionMnemonicDialog(this.dialogMnemonicLocator)
 	}

--- a/tests/playwright/support/sections/SectionNewMenu.ts
+++ b/tests/playwright/support/sections/SectionNewMenu.ts
@@ -28,6 +28,29 @@ export class SectionNewMenu {
 		return this.getMenuEntry(/New folder/i)
 	}
 
+	public getUploadFilesEntry(): Locator {
+		return this.getMenuEntry(/Upload files/i)
+	}
+
+	/**
+	 * Upload files through the "Upload files" entry of the new menu.
+	 *
+	 * The entry opens the browser's file picker, which is not part of the page -
+	 * Playwright hands it over as a `filechooser` event, so the files never have
+	 * to exist on disk. The listener is armed before the entry is clicked, as the
+	 * event fires synchronously with the click.
+	 *
+	 * Note that every uploaded file is a separate operation on the server, so pass
+	 * one file per call when the metadata write of each has to be awaited.
+	 *
+	 * @param files - The files to upload
+	 */
+	public async uploadFiles(...files: { name: string, mimeType: string, buffer: Buffer }[]): Promise<void> {
+		const fileChooser = this.page.waitForEvent('filechooser')
+		await this.getUploadFilesEntry().click()
+		await (await fileChooser).setFiles(files)
+	}
+
 	/**
 	 * Trigger the "New encrypted folder" entry and wait until the dialog has got
 	 * past its initial "Checking encryption setup …" step.

--- a/tests/playwright/support/utils/e2ee.ts
+++ b/tests/playwright/support/utils/e2ee.ts
@@ -27,6 +27,36 @@ export async function createEncryptedRootFolder(filesApp: FilesAppPage, name: st
 }
 
 /**
+ * Create a folder inside the encrypted folder the files app is navigated into,
+ * and wait for the metadata of that parent to be written back.
+ *
+ * @param page - Page the files app runs on
+ * @param filesApp - The files app, navigated into an encrypted folder
+ * @param name - Name of the folder to create
+ */
+export async function createFolderInEncryptedFolder(page: Page, filesApp: FilesAppPage, name: string): Promise<void> {
+	await withEncryptedFolderUpdate(page, () => filesApp.openNewMenu()
+		.then((menu) => menu.createNewFolder())
+		.then((dialog) => dialog.createFolder(name)))
+}
+
+/**
+ * Upload a text file into the encrypted folder the files app is navigated into,
+ * and wait for the metadata of that folder to be written back.
+ *
+ * One file per call: each upload is its own lock-write-unlock cycle, and
+ * {@link withEncryptedFolderUpdate} can only await one of them.
+ *
+ * @param page - Page the files app runs on
+ * @param filesApp - The files app, navigated into an encrypted folder
+ * @param name - Name of the file to create
+ * @param content - Contents of the file
+ */
+export async function uploadFileToEncryptedFolder(page: Page, filesApp: FilesAppPage, name: string, content?: string): Promise<void> {
+	await withEncryptedFolderUpdate(page, () => filesApp.uploadTextFile(name, content))
+}
+
+/**
  * Run an action that mutates the contents of an encrypted folder and wait for
  * the app to have written the folder's metadata back to the server.
  *


### PR DESCRIPTION
Add some e2e tests for #1950 

Disclosure: This was AI assisted with Claude Opus 5. Changes are manually reviewed.
## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
