### PR TITLE
fix: add some leeway for certificate validation

### DIFF
--- a/src/services/crypto.spec.ts
+++ b/src/services/crypto.spec.ts
@@ -3,10 +3,55 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { X509Certificate } from '@peculiar/x509'
-import { expect, test } from 'vitest'
-import { base64ToBuffer } from './bufferUtils.ts'
-import { generateAESKey, sha256Hash, validateCertificateSignature } from './crypto.ts'
+import { BasicConstraintsExtension, X509Certificate, X509CertificateGenerator } from '@peculiar/x509'
+import stringify from 'safe-stable-stringify'
+import { describe, expect, test } from 'vitest'
+import { RootMetadata } from '../models/RootMetadata.ts'
+import { base64ToBuffer, bufferToPem, stringToBuffer } from './bufferUtils.ts'
+import { exportRSAKey, generateAESKey, sha256Hash, validateCertificateSignature, validateCMSSignature } from './crypto.ts'
+import { generatePrivateKey } from './privateKeyUtils.ts'
+
+const MINUTE = 60_000
+
+const userId = 'alice'
+const userKeys = await generatePrivateKey()
+const serverKeys = await globalThis.crypto.subtle.generateKey(
+	{
+		name: 'RSASSA-PKCS1-v1_5',
+		modulusLength: 2048,
+		publicExponent: new Uint8Array([1, 0, 1]),
+		hash: 'SHA-256',
+	},
+	true,
+	['sign', 'verify'],
+)
+const serverPublicKeyPem = bufferToPem(await exportRSAKey(serverKeys.publicKey), 'public')
+
+/**
+ * Create a user certificate signed by the server key, like the server does when signing a CSR.
+ *
+ * @param validity - The validity period of the certificate, relative to now in milliseconds
+ * @param validity.notBefore - Start of the validity period, defaults to one hour ago
+ * @param validity.notAfter - End of the validity period, defaults to one hour from now
+ */
+async function createUserCertificate({ notBefore = -60 * MINUTE, notAfter = 60 * MINUTE } = {}): Promise<X509Certificate> {
+	const now = Date.now()
+	const certificate = await X509CertificateGenerator.create({
+		serialNumber: '01',
+		subject: `CN=${userId}`,
+		issuer: `CN=${userId}`,
+		notBefore: new Date(now + notBefore),
+		notAfter: new Date(now + notAfter),
+		publicKey: userKeys.publicKey,
+		signingKey: serverKeys.privateKey,
+		extensions: [
+			// the server signs the user certificates as a CA certificate
+			new BasicConstraintsExtension(true, undefined, true),
+		],
+	})
+	certificate.privateKey = userKeys.privateKey
+	return certificate
+}
 
 test('sha256Hash correctly returns a hex string', async () => {
 	const buffer = 'KPJswKr0owRxrcj4/3SRIw=='
@@ -31,6 +76,96 @@ test('Validate user certificate signed with SHA-256', async () => {
 	const result = await validateCertificateSignature(new X509Certificate(certificate), rawPublicKey)
 
 	expect(result).toBeTruthy()
+})
+
+describe('validateCertificateSignature', () => {
+	test('accepts a currently valid certificate', async () => {
+		const certificate = await createUserCertificate()
+		expect(await validateCertificateSignature(certificate, serverPublicKeyPem)).toBe(true)
+	})
+
+	test('rejects a certificate signed by another key', async () => {
+		const otherKeys = await globalThis.crypto.subtle.generateKey(
+			{
+				name: 'RSASSA-PKCS1-v1_5',
+				modulusLength: 2048,
+				publicExponent: new Uint8Array([1, 0, 1]),
+				hash: 'SHA-256',
+			},
+			true,
+			['sign', 'verify'],
+		)
+		const certificate = await createUserCertificate()
+
+		const otherPublicKeyPem = bufferToPem(await exportRSAKey(otherKeys.publicKey), 'public')
+		expect(await validateCertificateSignature(certificate, otherPublicKeyPem)).toBe(false)
+	})
+
+	test('rejects an expired certificate', async () => {
+		const certificate = await createUserCertificate({ notBefore: -60 * MINUTE, notAfter: -5 * MINUTE })
+		expect(await validateCertificateSignature(certificate, serverPublicKeyPem)).toBe(false)
+	})
+
+	test('accepts a certificate that expired within the allowed leeway', async () => {
+		const certificate = await createUserCertificate({ notBefore: -60 * MINUTE, notAfter: -MINUTE / 2 })
+		expect(await validateCertificateSignature(certificate, serverPublicKeyPem)).toBe(true)
+	})
+
+	test('rejects a certificate that is not yet valid', async () => {
+		const certificate = await createUserCertificate({ notBefore: 5 * MINUTE, notAfter: 60 * MINUTE })
+		expect(await validateCertificateSignature(certificate, serverPublicKeyPem)).toBe(false)
+	})
+
+	test('accepts a certificate that is not yet valid but within the allowed leeway', async () => {
+		const certificate = await createUserCertificate({ notBefore: MINUTE / 2, notAfter: 60 * MINUTE })
+		expect(await validateCertificateSignature(certificate, serverPublicKeyPem)).toBe(true)
+	})
+})
+
+describe('validateCMSSignature', () => {
+	/**
+	 * Sign metadata with the given certificate, like the client does when updating the metadata.
+	 *
+	 * @param certificate - The signers certificate, including the private key
+	 */
+	async function signMetadata(certificate: X509Certificate) {
+		const metadata = await RootMetadata.createNew()
+		await metadata.addUser(userId, certificate)
+		const exported = await metadata.export(certificate)
+
+		return [
+			stringToBuffer(btoa(stringify(exported.metadata)!)),
+			base64ToBuffer(exported.signature),
+			exported.metadata.users,
+		] as const
+	}
+
+	test('accepts a signature of a currently valid certificate', async () => {
+		const signed = await signMetadata(await createUserCertificate())
+		expect(await validateCMSSignature(...signed)).toBe(true)
+	})
+
+	test('rejects a signature of an expired certificate', async () => {
+		const signed = await signMetadata(await createUserCertificate({ notBefore: -60 * MINUTE, notAfter: -5 * MINUTE }))
+		// PKI.js throws instead of returning false if the certificate chain is not valid
+		await expect(validateCMSSignature(...signed)).rejects.toThrow('The certificate is either not yet valid or expired')
+	})
+
+	test('accepts a signature of a certificate that expired within the allowed leeway', async () => {
+		const signed = await signMetadata(await createUserCertificate({ notBefore: -60 * MINUTE, notAfter: -MINUTE / 2 }))
+		expect(await validateCMSSignature(...signed)).toBe(true)
+	})
+
+	test('rejects a signature of a certificate that is not yet valid', async () => {
+		const signed = await signMetadata(await createUserCertificate({ notBefore: 5 * MINUTE, notAfter: 60 * MINUTE }))
+		// PKI.js throws instead of returning false if the certificate chain is not valid
+		await expect(validateCMSSignature(...signed)).rejects.toThrow('The certificate is either not yet valid or expired')
+	})
+
+	test('accepts a signature of a certificate that is not yet valid but within the allowed leeway', async () => {
+		const signed = await signMetadata(await createUserCertificate({ notBefore: MINUTE / 2, notAfter: 60 * MINUTE }))
+		expect(await validateCMSSignature(...signed)).toBe(true)
+	})
 })
 
 test('generateAESKey', async () => {

--- a/src/services/crypto.ts
+++ b/src/services/crypto.ts
@@ -8,6 +8,9 @@ import type { IRawMetadataUser } from '../models/metadata.d.ts'
 
 import { Certificate, ContentInfo, CryptoEngine, SignedData } from 'pkijs'
 import { bufferToHex, pemToBuffer } from './bufferUtils.ts'
+import logger from './logger.ts'
+
+const CERTIFICATE_VALIDITY_LEEWAY_MS = 60_000 // allow up to 1 minute of leeway for certificate validity checks
 
 /**
  * Encrypts content using AES-GCM encryption algorithm
@@ -158,12 +161,51 @@ export async function sha256Hash(buffer: Uint8Array<ArrayBuffer>): Promise<strin
  * @param publicKeyPEM - The public key in PEM format to use for validation
  */
 export async function validateCertificateSignature(certificate: X509Certificate, publicKeyPEM: string): Promise<boolean> {
+	const NOW = Date.now()
 	const publicKey = await loadServerPublicKey(
 		pemToBuffer(publicKeyPEM),
 		certificate.signatureAlgorithm.hash.name as 'SHA-1' | 'SHA-256',
 	)
 
-	return certificate.verify({ publicKey }, getPatchedCrypto())
+	if (!await certificate.verify({ publicKey, signatureOnly: true }, getPatchedCrypto())) {
+		logger.debug('Certificate signature validation failed', { subject: certificate.subject })
+		return false
+	}
+
+	const notBefore = certificate.notBefore.getTime()
+	if (notBefore > (NOW + CERTIFICATE_VALIDITY_LEEWAY_MS)) {
+		logger.debug('Certificate is not yet valid', { subject: certificate.subject, notBefore, NOW })
+		return false
+	}
+
+	const notAfter = certificate.notAfter.getTime()
+	if (notAfter < (NOW - CERTIFICATE_VALIDITY_LEEWAY_MS)) {
+		logger.debug('Certificate has expired', { subject: certificate.subject, notAfter, NOW })
+		return false
+	}
+
+	logger.debug('Certificate signature validation succeeded', { subject: certificate.subject })
+	return true
+}
+
+/**
+ * Get the point in time to validate a certificate validity period against.
+ *
+ * The current time is moved into the validity period, if it is outside of it by no more than the
+ * allowed leeway. This is needed for APIs like PKI.js which only accept a single point in time
+ * instead of a leeway, so a slightly off client clock does not reject an otherwise valid certificate.
+ *
+ * @param notBefore - The date on which the certificate validity period begins
+ * @param notAfter - The date on which the certificate validity period ends
+ */
+function getValidityCheckDate(notBefore: Date, notAfter: Date): Date {
+	const now = Date.now()
+	const withinValidityPeriod = Math.min(Math.max(now, notBefore.getTime()), notAfter.getTime())
+	if (Math.abs(withinValidityPeriod - now) > CERTIFICATE_VALIDITY_LEEWAY_MS) {
+		// off by more than the allowed leeway, so the certificate is really not valid
+		return new Date(now)
+	}
+	return new Date(withinValidityPeriod)
 }
 
 /**
@@ -216,6 +258,8 @@ export async function validateCMSSignature(signedData: Uint8Array<ArrayBuffer>, 
 			trustedCerts: [signerCertificate],
 			data: signedData.buffer,
 			checkChain: true,
+			// the chain check also validates the certificate validity period, so allow some clock leeway
+			checkDate: getValidityCheckDate(signerCertificate.notBefore.value, signerCertificate.notAfter.value),
 		},
 		getPatchedCryptoEngine(),
 	)

--- a/src/store/keys.ts
+++ b/src/store/keys.ts
@@ -8,7 +8,7 @@ import { getSharingToken, isPublicShare } from '@nextcloud/sharing/public'
 import { X509Certificate } from '@peculiar/x509'
 import * as api from '../services/api.ts'
 import { pemToBuffer } from '../services/bufferUtils.ts'
-import { loadServerPublicKey } from '../services/crypto.ts'
+import { loadServerPublicKey, validateCertificateSignature } from '../services/crypto.ts'
 import { promptUserForMnemonic } from '../services/mnemonicDialogs.ts'
 import { decryptPrivateKey } from '../services/privateKeyUtils.ts'
 
@@ -16,6 +16,7 @@ let privateKey: CryptoKey | undefined
 let publicKey: CryptoKey | undefined
 let certificate: X509Certificate | undefined
 let serverKey: CryptoKey | undefined
+let serverKeyPem: string | undefined
 
 const userKeys = new Map<string, X509Certificate | undefined>()
 const MEMORY_LIMIT = 100
@@ -31,10 +32,19 @@ const currentUser = isPublicShare()
  */
 export async function getServerKey(): Promise<CryptoKey> {
 	if (!serverKey) {
-		const serverKeyPem = await api.getServerPublicKey()
-		serverKey = await loadServerPublicKey(pemToBuffer(serverKeyPem), 'SHA-256')
+		serverKey = await loadServerPublicKey(pemToBuffer(await getServerKeyPem()), 'SHA-256')
 	}
 	return serverKey!
+}
+
+/**
+ * Get the server's public key in PEM format.
+ *
+ * If not already loaded, it fetches it from the API.
+ */
+async function getServerKeyPem(): Promise<string> {
+	serverKeyPem ??= await api.getServerPublicKey()
+	return serverKeyPem
 }
 
 /**
@@ -94,7 +104,7 @@ export async function loadPublicKey(): Promise<boolean> {
 		}
 
 		const cert = new X509Certificate(pem)
-		if (!cert.verify({ publicKey: await getServerKey() })) {
+		if (!await validateCertificateSignature(cert, await getServerKeyPem())) {
 			throw new Error('User certificate signature verification failed')
 		}
 		if (privateKey) {
@@ -173,7 +183,7 @@ export async function getUserKey(userId: string): Promise<X509Certificate | unde
 		const pem = await api.getPublicKey(userId)
 		if (pem) {
 			const cert = new X509Certificate(pem)
-			if (!cert.verify({ publicKey: await getServerKey() })) {
+			if (!await validateCertificateSignature(cert, await getServerKeyPem())) {
 				throw new Error('User certificate signature verification failed')
 			}
 			setUserKey(userId, cert)


### PR DESCRIPTION
Server and client are not always 100% synchronized (time). So if you setup encryption the cert might fail verification if server and browser a couple of seconds out-of-sync.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

**used AI to generate unit tests**
