### PR TITLE
fix: handle failed uploads

### DIFF
--- a/src/middleware/usePutInterceptor.spec.ts
+++ b/src/middleware/usePutInterceptor.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { X509Certificate } from '@peculiar/x509'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+	adminMnemonic,
+	adminPrivateKeyInfo,
+	rootFolderMetadata,
+} from '../../__tests__/consts.spec.ts'
+import { RootMetadata } from '../models/RootMetadata.ts'
+import * as api from '../services/api.ts'
+import { base64ToBuffer } from '../services/bufferUtils.ts'
+import { decryptWithAES, loadAESPrivateKey } from '../services/crypto.ts'
+import { decryptPrivateKey } from '../services/privateKeyUtils.ts'
+import * as metadataStore from '../store/metadata.ts'
+import { usePutInterceptor } from './usePutInterceptor.ts'
+
+vi.mock('@nextcloud/auth', () => ({ getCurrentUser: () => ({ uid: 'admin' }) }))
+vi.mock('@nextcloud/sharing/public', () => ({
+	isPublicShare: () => false,
+	getSharingToken: () => null,
+}))
+vi.mock('../store/keys.ts', () => ({
+	getCertificate: async () => {
+		const certificate = new X509Certificate(rootFolderMetadata.users[1]!.certificate)
+		certificate.privateKey = await decryptPrivateKey(adminPrivateKeyInfo, adminMnemonic)
+		return certificate
+	},
+	getPrivateKey: async () => await decryptPrivateKey(adminPrivateKeyInfo, adminMnemonic),
+	loadPrivateKey: async () => true,
+	loadPublicKey: async () => true,
+}))
+vi.mock('../services/api.ts', { spy: true })
+
+/** The e2ee root folder, as shipped by the metadata fixture */
+const ROOT = '/remote.php/dav/files/admin/New folder'
+/** The file within the e2ee root folder, named "test.txt" */
+const FILE_UUID = 'ad3b12554e0d4364854ae3e21b170152'
+/** The contents of the e2ee root folder, as shipped by the metadata fixture */
+const CONTENTS = ['Test', 'test.txt']
+/** The counter of the metadata fixture */
+const COUNTER = 5
+/** The file id of the e2ee root folder */
+const ROOT_ID = '89'
+
+const FILE_CONTENT = 'the contents of the uploaded file\n'
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	vi.mocked(api.lockFolder).mockResolvedValue('lock-token')
+	vi.mocked(api.unlockFolder).mockResolvedValue()
+	vi.mocked(api.updateMetadata).mockResolvedValue()
+	vi.mocked(api.getMetadataByPath).mockRejectedValue(new api.NoMetadataError('No metadata found'))
+	metadataStore.deleteMetadata(ROOT)
+})
+
+describe('pass through', () => {
+	test('passes through a target that is not end-to-end encrypted', async () => {
+		const { context, next } = await runPut('/remote.php/dav/files/admin/unencrypted/file.txt')
+
+		expect(next).toHaveBeenCalledOnce()
+		expect(api.lockFolder).not.toHaveBeenCalled()
+		// the request reaches the server as it was, contents included
+		expect(context.req.headers.get('X-E2EE-SUPPORTED')).toBe(null)
+		expect(await context.req.text()).toBe(FILE_CONTENT)
+	})
+})
+
+describe('uploading a file', () => {
+	test('uploads the file encrypted under a uuid and adds it to the metadata', async () => {
+		const metadata = await seedRootFolder()
+
+		const { context, next } = await runPut(`${ROOT}/new file.txt`)
+
+		// the name of the file only exists in the metadata, the server gets a uuid
+		const uuid = uploadedName(context)
+		expect(uuid).toMatch(/^[0-9a-f]{32}$/)
+		expect(metadata.getUuid('new file.txt')).toBe(uuid)
+		expect(metadata.listContents()).toEqual([...CONTENTS, 'new file.txt'])
+		// and the real mimetype travels in the metadata as well
+		expect(metadata.getFile(uuid)!.mimetype).toBe('text/plain')
+
+		// within the lock of the folder, using the next counter
+		expect(next).toHaveBeenCalledOnce()
+		expect(api.lockFolder).toHaveBeenCalledExactlyOnceWith(ROOT_ID, COUNTER + 1)
+		expect(api.updateMetadata).toHaveBeenCalledOnce()
+		expect(api.unlockFolder).toHaveBeenCalledExactlyOnceWith(ROOT_ID, 'lock-token')
+		// and the request itself was authorized and gives nothing away
+		expect(context.req.headers.get('E2E-TOKEN')).toBe('lock-token')
+		expect(context.req.headers.get('X-E2EE-SUPPORTED')).toBe('true')
+		expect(context.req.headers.get('Content-Type')).toBe('application/octet-stream')
+	})
+
+	test('uploads contents that the key of the metadata entry decrypts', async () => {
+		const metadata = await seedRootFolder()
+
+		const { context } = await runPut(`${ROOT}/new file.txt`)
+
+		// the entry has to describe the very bytes that were uploaded - a key, a
+		// nonce or a tag that belongs to anything else is a file lost for good
+		const entry = metadata.getFile(uploadedName(context))!
+		const uploaded = await context.req.arrayBuffer()
+		expect(new TextDecoder().decode(uploaded)).not.toContain('contents')
+
+		const decrypted = await decryptWithAES(
+			uploaded,
+			await loadAESPrivateKey(base64ToBuffer(entry.key)),
+			{ iv: base64ToBuffer(entry.nonce) },
+		)
+		expect(new TextDecoder().decode(decrypted)).toBe(FILE_CONTENT)
+	})
+
+	test('gives a file a unique name if the folder already has one of that name', async () => {
+		const metadata = await seedRootFolder()
+
+		const { context } = await runPut(`${ROOT}/test.txt`)
+
+		// the file that is already there keeps its name and its uuid
+		expect(uploadedName(context)).not.toBe(FILE_UUID)
+		expect(metadata.getFile(FILE_UUID)!.filename).toBe('test.txt')
+		expect(metadata.listContents()).toEqual([...CONTENTS, 'test (1).txt'])
+	})
+
+	test('keeps name and uuid when an existing file is overwritten', async () => {
+		const metadata = await seedRootFolder()
+
+		// the files app addresses a file by the name it has on the server, so an
+		// update arrives as a PUT to the uuid
+		const { context } = await runPut(`${ROOT}/${FILE_UUID}`)
+
+		expect(uploadedName(context)).toBe(FILE_UUID)
+		expect(metadata.getFile(FILE_UUID)!.filename).toBe('test.txt')
+		expect(metadata.listContents()).toEqual(CONTENTS)
+		expect(api.updateMetadata).toHaveBeenCalledOnce()
+	})
+})
+
+describe('an upload that failed', () => {
+	test('does not add the file to the metadata', async () => {
+		const metadata = await seedRootFolder()
+
+		const { context } = await runPut(`${ROOT}/failed.txt`, { status: 507 })
+
+		expect(metadata.listContents()).toEqual(CONTENTS)
+		expect(metadata.getUuid('failed.txt')).toBe(undefined)
+		expect(metadata.getFile(uploadedName(context))).toBe(undefined)
+		// the metadata on the server is left as it is, and the folder is unlocked again
+		expect(api.updateMetadata).not.toHaveBeenCalled()
+		expect(api.unlockFolder).toHaveBeenCalledExactlyOnceWith(ROOT_ID, 'lock-token')
+	})
+
+	test('reports the failure to the caller', async () => {
+		await seedRootFolder()
+
+		const { context } = await runPut(`${ROOT}/failed.txt`, { status: 507 })
+
+		expect(context.res.status).toBe(507)
+	})
+
+	test('leaves the counter where the next operation expects it', async () => {
+		const metadata = await seedRootFolder()
+
+		await runPut(`${ROOT}/failed.txt`, { status: 507 })
+
+		// A counter that is off keeps the server from accepting the metadata of every
+		// following operation, as it locks the folder with the one it expects to write.
+		expect(metadata.counter).toBe(COUNTER)
+		await runPut(`${ROOT}/other.txt`)
+		expect(api.lockFolder).toHaveBeenLastCalledWith(ROOT_ID, COUNTER + 1)
+	})
+
+	test('does not take the name of the file from a second attempt', async () => {
+		const metadata = await seedRootFolder()
+
+		await runPut(`${ROOT}/retried.txt`, { status: 507 })
+		await runPut(`${ROOT}/retried.txt`)
+
+		expect(metadata.listContents()).toEqual([...CONTENTS, 'retried.txt'])
+	})
+
+	test('is not persisted by the next upload that succeeds', async () => {
+		const metadata = await seedRootFolder()
+
+		await runPut(`${ROOT}/failed.txt`, { status: 507 })
+		await runPut(`${ROOT}/other.txt`)
+
+		// the metadata that reached the server is the one this object holds, so the
+		// entry of the failed upload may not be part of it anymore
+		expect(metadata.listContents()).toEqual([...CONTENTS, 'other.txt'])
+		expect(api.updateMetadata).toHaveBeenCalledOnce()
+	})
+})
+
+/**
+ * Seed the cache with the metadata of the e2ee root folder, like a PROPFIND would.
+ */
+async function seedRootFolder(): Promise<RootMetadata> {
+	const privateKey = await decryptPrivateKey(adminPrivateKeyInfo, adminMnemonic)
+	const metadata = await RootMetadata.fromJson(rootFolderMetadata, 'admin', privateKey)
+	metadataStore.setMetadata(ROOT, ROOT_ID, metadata)
+	return metadata
+}
+
+/**
+ * Run the PUT interceptor for the given path.
+ *
+ * @param path - The path to upload to
+ * @param options - Contents to upload and the status the upload is answered with
+ */
+async function runPut(path: string, options: { content?: string, status?: number } = {}) {
+	const { content = FILE_CONTENT, status = 201 } = options
+	const context = {
+		req: new Request(`https://example.com${path}`, {
+			method: 'PUT',
+			body: content,
+			headers: { 'Content-Type': 'text/plain' },
+		}),
+		res: new Response(),
+		type: 'fetch' as const,
+	}
+	// `next` is what performs the request, so it is also what answers it
+	const next = vi.fn(async () => {
+		context.res = new Response(null, { status })
+	})
+
+	await usePutInterceptor(context, next)
+	return { context, next }
+}
+
+/**
+ * The name the file was uploaded under, i.e. the name it has on the server.
+ *
+ * @param context - The context the interceptor ran on
+ */
+function uploadedName(context: { req: Request }): string {
+	return decodeURIComponent(new URL(context.req.url).pathname.split('/').pop()!)
+}

--- a/src/middleware/usePutInterceptor.ts
+++ b/src/middleware/usePutInterceptor.ts
@@ -85,7 +85,13 @@ export async function usePutInterceptor(context: FetchContext, next: () => Promi
 			headers,
 			body: result.encryptedContent,
 		})
+
 		await next()
+		if (!context.res.ok) {
+			logger.error('Failed to upload encrypted file', { status: context.res.status, statusText: context.res.statusText })
+			metadata.metadata.rollback()
+			return // do not update metadata if the upload failed
+		}
 
 		const { metadata: rawMetadata, signature } = await metadata.metadata.export(await keyStore.getCertificate())
 		await api.updateMetadata(metadata.id, stringify(rawMetadata), lockToken, signature)

--- a/src/models/Metadata.spec.ts
+++ b/src/models/Metadata.spec.ts
@@ -1,0 +1,183 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { IMetadataFile } from './metadata.d.ts'
+
+import { beforeEach, describe, expect, test } from 'vitest'
+import * as Alice from '../../__tests__/fixtures/Alice.spec.ts'
+import { Metadata } from './Metadata.ts'
+
+describe('Rolling back metadata', () => {
+	let metadata: Metadata
+
+	beforeEach(async () => {
+		metadata = await Metadata.createNew(await metadataKey())
+	})
+
+	test('should undo an added file', () => {
+		metadata.addFile('uuid-1', fileInfo('added.txt'))
+		expect(metadata.listContents()).toEqual(['added.txt'])
+
+		metadata.rollback()
+
+		expect(metadata.listContents()).toEqual([])
+		expect(metadata.getFile('uuid-1')).toBe(undefined)
+	})
+
+	test('should undo an added folder', () => {
+		metadata.addFolder('uuid-1', 'added')
+
+		metadata.rollback()
+
+		expect(metadata.listContents()).toEqual([])
+		expect(metadata.getFolder('uuid-1')).toBe(undefined)
+	})
+
+	test('should undo a deleted file', async () => {
+		metadata.addFile('uuid-1', fileInfo('kept.txt'))
+		await metadata.export(await signingCertificate())
+
+		metadata.deleteFile('uuid-1')
+		expect(metadata.listContents()).toEqual([])
+
+		metadata.rollback()
+
+		expect(metadata.getFile('uuid-1')).toEqual(fileInfo('kept.txt'))
+		expect(metadata.hasUuid('uuid-1')).toBe(true)
+	})
+
+	test('should undo a deleted folder', async () => {
+		metadata.addFolder('uuid-1', 'kept')
+		await metadata.export(await signingCertificate())
+
+		metadata.deleteFolder('uuid-1')
+
+		metadata.rollback()
+
+		expect(metadata.getFolder('uuid-1')).toBe('kept')
+	})
+
+	test('should undo a rename', async () => {
+		metadata.addFile('uuid-1', fileInfo('before.txt'))
+		metadata.addFolder('uuid-2', 'before')
+		await metadata.export(await signingCertificate())
+
+		metadata.rename('uuid-1', 'after.txt')
+		metadata.rename('uuid-2', 'after')
+
+		metadata.rollback()
+
+		expect(metadata.getFile('uuid-1')!.filename).toBe('before.txt')
+		expect(metadata.getFolder('uuid-2')).toBe('before')
+	})
+
+	test('should undo the counter increment that comes with a change', () => {
+		expect(metadata.counter).toBe(0)
+		metadata.addFile('uuid-1', fileInfo('added.txt'))
+		expect(metadata.counter).toBe(1)
+
+		metadata.rollback()
+
+		expect(metadata.counter).toBe(0)
+	})
+
+	test('should undo a replaced metadata key', async () => {
+		const original = metadata.key
+		metadata.key = await metadataKey()
+
+		metadata.rollback()
+
+		expect(metadata.key).toBe(original)
+	})
+
+	test('should keep the changes that were exported', async () => {
+		const certificate = await signingCertificate()
+		metadata.addFile('uuid-1', fileInfo('exported.txt'))
+		await metadata.export(certificate)
+
+		metadata.addFile('uuid-2', fileInfo('not-exported.txt'))
+		metadata.rollback()
+
+		// the export is the point the metadata was handed to the server, so that is
+		// the state a rollback returns to - not the state it was created in
+		expect(metadata.listContents()).toEqual(['exported.txt'])
+		expect(metadata.counter).toBe(1)
+
+		// and the counter of the next change carries on from there
+		metadata.addFile('uuid-3', fileInfo('next.txt'))
+		expect(metadata.counter).toBe(2)
+	})
+
+	test('should undo changes made after a rollback as well', async () => {
+		metadata.addFile('uuid-1', fileInfo('exported.txt'))
+		await metadata.export(await signingCertificate())
+
+		metadata.addFile('uuid-2', fileInfo('first-try.txt'))
+		metadata.rollback()
+		metadata.addFile('uuid-3', fileInfo('second-try.txt'))
+		metadata.rollback()
+
+		expect(metadata.listContents()).toEqual(['exported.txt'])
+	})
+
+	test('should do nothing when called again', () => {
+		metadata.addFile('uuid-1', fileInfo('added.txt'))
+		metadata.rollback()
+		metadata.rollback()
+
+		expect(metadata.listContents()).toEqual([])
+		expect(metadata.counter).toBe(0)
+	})
+
+	test('should not be undone by a following export', async () => {
+		const certificate = await signingCertificate()
+		metadata.addFile('uuid-1', fileInfo('rolled-back.txt'))
+		metadata.rollback()
+
+		// the rolled back entry may not come back through the export, which is what
+		// would happen if it was still held anywhere
+		const exported = await metadata.export(certificate)
+		const reloaded = await Metadata.fromJson(exported.metadata, metadata.key)
+		expect(reloaded.listContents()).toEqual([])
+	})
+})
+
+/**
+ * A file entry as the PUT interceptor builds it - only the name is of interest
+ * here, the rest is what the metadata carries along.
+ *
+ * @param filename - Name of the file
+ */
+function fileInfo(filename: string): IMetadataFile {
+	return {
+		filename,
+		mimetype: 'text/plain',
+		nonce: 'bm9uY2U=',
+		authenticationTag: 'dGFn',
+		key: 'a2V5',
+	}
+}
+
+/**
+ * A metadata key, as any folder metadata needs one to be created.
+ */
+function metadataKey(): Promise<CryptoKey> {
+	return globalThis.crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, true, ['encrypt', 'decrypt'])
+}
+
+/**
+ * A certificate that can sign, which is what exporting metadata needs.
+ */
+async function signingCertificate() {
+	const certificate = Alice.certificate
+	certificate.privateKey = await globalThis.crypto.subtle.importKey(
+		'jwk',
+		Alice.privateKey,
+		{ name: 'RSA-OAEP', hash: 'SHA-256' },
+		true,
+		['decrypt'],
+	)
+	return certificate
+}

--- a/src/models/Metadata.ts
+++ b/src/models/Metadata.ts
@@ -16,6 +16,16 @@ import logger from '../services/logger.ts'
 import { decryptMetadata } from '../services/metadata.ts'
 import { ensureKeyUsage } from '../services/rsaUtils.ts'
 
+/**
+ * A copy of everything a metadata object holds, taken at the point it last matched
+ * the metadata on the server - see {@link Metadata.rollback}.
+ */
+interface IMetadataState {
+	metadata: IMetadata
+	metadataKey: CryptoKey
+	version: string
+}
+
 export class Metadata<MetaData extends IRawMetadata = IRawMetadata> {
 	protected _metadataKey: CryptoKey
 	protected _metadata: IMetadata
@@ -23,6 +33,8 @@ export class Metadata<MetaData extends IRawMetadata = IRawMetadata> {
 	protected _modified: boolean
 	/** The internal real metadata */
 	#metadata: IMetadata
+	/** The state {@link rollback} returns to */
+	#committedState: IMetadataState
 
 	/**
 	 * Constructor for E2EE Metadata
@@ -57,6 +69,12 @@ export class Metadata<MetaData extends IRawMetadata = IRawMetadata> {
 				return true
 			},
 		})
+
+		// Nothing has been changed yet, so this is the state of the folder on the
+		// server. Taken here and not through `_commitState`, as calling an
+		// overridden method from a constructor would run it before the fields of
+		// the subclass exist.
+		this.#committedState = this.#createState()
 	}
 
 	public get counter(): number {
@@ -199,6 +217,14 @@ export class Metadata<MetaData extends IRawMetadata = IRawMetadata> {
 	}
 
 	/**
+	 * Undo every change made since this metadata was loaded or last exported.
+	 */
+	public rollback(): void {
+		logger.debug('Rolling back metadata changes')
+		this._restoreState()
+	}
+
+	/**
 	 * Export the metadata and its signature
 	 *
 	 * @param certificate - The x509 certificate including the private key of the current user for signing
@@ -214,6 +240,7 @@ export class Metadata<MetaData extends IRawMetadata = IRawMetadata> {
 		// apply all changes
 		this.#metadata.counter = this.counter
 		this._modified = false
+		this._commitState()
 
 		return { metadata, signature }
 	}
@@ -232,6 +259,44 @@ export class Metadata<MetaData extends IRawMetadata = IRawMetadata> {
 
 	public static async createNew(metadataKey: CryptoKey): Promise<Metadata> {
 		return new Metadata(metadataKey)
+	}
+
+	/**
+	 * Remember the current state as the one a {@link rollback} returns to, i.e. as
+	 * the state the server has.
+	 *
+	 * Subclasses have to extend this to cover what they hold themselves, and to
+	 * call it once they are done setting up an instance from existing metadata.
+	 */
+	protected _commitState(): void {
+		this.#committedState = this.#createState()
+	}
+
+	/**
+	 * Restore the state remembered by the last {@link _commitState}.
+	 *
+	 * Subclasses have to extend this to cover what they hold themselves.
+	 */
+	protected _restoreState(): void {
+		// Assigned into the existing object instead of replacing it: this object is
+		// the target of the `_metadata` proxy, so swapping it would leave every
+		// change from here on going to an object nobody reads anymore. Every
+		// property of the metadata is part of the state, so all of them are restored.
+		Object.assign(this.#metadata, structuredClone(this.#committedState.metadata))
+		this._metadataKey = this.#committedState.metadataKey
+		this._version = this.#committedState.version
+		this._modified = false
+	}
+
+	/**
+	 * Take a copy of the current state, deep enough to be unaffected by later changes.
+	 */
+	#createState(): IMetadataState {
+		return {
+			metadata: structuredClone(this.#metadata),
+			metadataKey: this._metadataKey,
+			version: this._version,
+		}
 	}
 
 	protected async _exportMetadata(): Promise<MetaData> {

--- a/src/models/RootMetadata.spec.ts
+++ b/src/models/RootMetadata.spec.ts
@@ -47,6 +47,57 @@ describe('Export metadata', () => {
 	})
 })
 
+describe('Rolling back root metadata', () => {
+	/**
+	 * The users are held next to the metadata itself, so a rollback has to cover
+	 * them separately - and with them the version, which adding a public share to a
+	 * folder raises.
+	 */
+	test('should undo an added user', async () => {
+		const cert = Alice.certificate
+		cert.privateKey = await getPrivateKey(Alice.privateKey)
+		const metadata = await RootMetadata.createNew()
+		await metadata.addUser(Alice.userId, cert)
+		await metadata.export(cert)
+
+		// sharing the folder as a public share raises the version to 2.1
+		await metadata.addUser('s:share-token', Bob.certificate)
+		expect(metadata.getUsers()).toEqual([Alice.userId, 's:share-token'])
+
+		metadata.rollback()
+
+		expect(metadata.getUsers()).toEqual([Alice.userId])
+
+		const exported = await metadata.export(cert)
+		expect(exported.metadata.version).toBe('2.0')
+		expect(exported.metadata.users).toHaveLength(1)
+		// the key the user can decrypt the metadata with survived the rollback
+		expect(exported.metadata.users[0]!.encryptedMetadataKey).not.toBe('')
+	})
+
+	test('should undo marking the folder as deleted', async () => {
+		const cert = Alice.certificate
+		cert.privateKey = await getPrivateKey(Alice.privateKey)
+		const metadata = await RootMetadata.createNew()
+		await metadata.addUser(Alice.userId, cert)
+		metadata.addFolder('uuid-1', 'kept')
+		await metadata.export(cert)
+
+		metadata.markAsDeleted()
+		expect(metadata.listContents()).toEqual([])
+
+		metadata.rollback()
+
+		expect(metadata.listContents()).toEqual(['kept'])
+
+		const exported = await metadata.export(cert)
+		expect(exported.metadata.users).toHaveLength(1)
+		// marking the folder as deleted also empties the file drop entries, and an
+		// empty set of them is not the same as the none this folder ever had
+		expect(exported.metadata.filedrop).toBe(undefined)
+	})
+})
+
 export async function getPrivateKey(privateKeyJwk: JsonWebKey) {
 	return await self.crypto.subtle.importKey('jwk', privateKeyJwk, { name: 'RSA-OAEP', hash: 'SHA-256' }, true, ['decrypt'])
 }

--- a/src/models/RootMetadata.ts
+++ b/src/models/RootMetadata.ts
@@ -19,11 +19,16 @@ export class RootMetadata extends Metadata<IRawRootMetadata> {
 	#filedrop?: Record<string, FileDropEntry>
 	#users: IRawMetadataUser[]
 	#usersModified: boolean
+	/** Part of the state a rollback returns to, see `_commitState` */
+	#committedFiledrop?: Record<string, FileDropEntry>
+	/** Part of the state a rollback returns to, see `_commitState` */
+	#committedUsers: IRawMetadataUser[]
 
 	protected constructor(metadataKey: CryptoKey, version: string = '2.0', initialMetadata?: IMetadata) {
 		super(metadataKey, version, initialMetadata)
 		this.#users = []
 		this.#usersModified = false
+		this.#committedUsers = []
 	}
 
 	public get fileDropEntries(): string[] {
@@ -101,6 +106,23 @@ export class RootMetadata extends Metadata<IRawRootMetadata> {
 		this._metadata.files = {}
 		this._metadata.folders = {}
 		this.#filedrop = {}
+	}
+
+	/**
+	 * The users and the file drop entries are held next to the metadata itself, so
+	 * they need to be remembered and restored next to it as well.
+	 */
+	protected override _commitState(): void {
+		super._commitState()
+		this.#committedUsers = this.#users.map((user) => ({ ...user }))
+		this.#committedFiledrop = this.#filedrop && { ...this.#filedrop }
+	}
+
+	protected override _restoreState(): void {
+		super._restoreState()
+		this.#users = this.#committedUsers.map((user) => ({ ...user }))
+		this.#usersModified = false
+		this.#filedrop = this.#committedFiledrop && { ...this.#committedFiledrop }
 	}
 
 	protected async _exportMetadata(): Promise<IRawRootMetadata> {
@@ -203,6 +225,12 @@ export class RootMetadata extends Metadata<IRawRootMetadata> {
 			metadata.#filedrop = Object.fromEntries(fileDropEntries)
 		}
 		metadata.#users = json.users
+
+		// The users and the file drop entries are set after the constructor ran, so
+		// the state a rollback returns to has to be taken here - this is where the
+		// instance is the metadata that was passed in, and nothing more.
+		metadata._commitState()
+
 		return metadata
 	}
 }


### PR DESCRIPTION
* resolves https://github.com/nextcloud/end_to_end_encryption/issues/1732

If you upload a file and it fails we need to rollback the local metadata.
Otherwise locally such a file exists when trying to upload a new file an invalid suffix would be added.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
