### PR TITLE
fix: resolve type error in propfind plugin

### DIFF
--- a/lib/Connector/Sabre/PropFindPlugin.php
+++ b/lib/Connector/Sabre/PropFindPlugin.php
@@ -86,7 +86,7 @@ class PropFindPlugin extends APlugin {
 	 */
 	public function updateProperty(PropFind $propFind, INode $node): void {
 		// only apply the plugin to files/directory, not to contacts or calendars
-		if (!$this->isFile($node->getName(), $node)) {
+		if (!$this->isFile((string)$node->getName(), $node)) {
 			return;
 		}
 


### PR DESCRIPTION
* resolves https://github.com/nextcloud/end_to_end_encryption/issues/1985

A bug in sabre causes numeric filenames to be returned as `int`, so we need to explicitly cast to `string`.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
