### PR TITLE
fix(propfind): don't let PROPFIND parsing/rebuilding failures break the whole file listing

### DIFF
--- a/src/middleware/usePropFindInterceptor.spec.ts
+++ b/src/middleware/usePropFindInterceptor.spec.ts
@@ -134,6 +134,43 @@ test('Does not decrypt the metadata of a listed e2ee root', async () => {
 	expect(xml.multistatus.response[2]!.propstat?.prop.permissions).toBe('GDNVCK')
 })
 
+test('does not corrupt a PROPFIND property that also carries an XML attribute when rebuilding the response', async () => {
+	// fast-xml-parser only wraps a node's text content in an object under the
+	// configured `textNodeName` key - instead of returning it as a plain string -
+	// when the node also has to carry other keys alongside it, e.g. an attribute.
+	// `parseXML()` (from the `webdav` package) parses with `textNodeName: 'text'`,
+	// so the `XMLBuilder` used to rebuild the response has to use the same value
+	// for the round trip to be symmetric. Without it, `XMLBuilder`'s own default
+	// (`'#text'`) does not recognise the wrapped text and serialises it as a
+	// literal `<text>` child element instead - plus an invalid `<@attr>` tag for
+	// the attribute itself - corrupting the response Nextcloud's own DAV client
+	// then fails to parse back ("Invalid tag name: text").
+	//
+	// No known Nextcloud DAV property currently ships an attribute like this
+	// (the one pre-existing case in these fixtures, `x1:share-permissions`'s
+	// inline `xmlns:x1`, is filtered out by the parser as a namespace
+	// declaration rather than kept as data), so this uses a synthetic one to
+	// pin the invariant regardless of whether one exists in the wild today.
+	const response = homeListingPropFindResponse.replace(
+		'<d:displayname>New folder</d:displayname>',
+		'<d:displayname synthetic-attr="1">New folder</d:displayname>',
+	)
+	expect(response).not.toBe(homeListingPropFindResponse)
+
+	const context = {
+		req: new Request('https://example.com/remote.php/dav/files/admin', { method: 'PROPFIND' }),
+		res: new Response(response),
+		type: 'fetch' as const,
+	}
+
+	await usePropFindInterceptor(context, async () => {})
+
+	const raw = await context.res.text()
+	expect(raw).not.toContain('<text>')
+	expect(raw).not.toContain('<@')
+	expect(raw).toContain('<displayname synthetic-attr="1">New folder</displayname>')
+})
+
 test('Correctly replace root file info in PROPFIND', async () => {
 	const metadata = await RootMetadata.fromJson(rootFolderMetadata, 'admin', await decryptPrivateKey(adminPrivateKeyInfo, adminMnemonic))
 	metadataStore.getMetadata

--- a/src/middleware/usePropFindInterceptor.spec.ts
+++ b/src/middleware/usePropFindInterceptor.spec.ts
@@ -171,6 +171,36 @@ test('does not corrupt a PROPFIND property that also carries an XML attribute wh
 	expect(raw).toContain('<displayname synthetic-attr="1">New folder</displayname>')
 })
 
+test('does not drop a boolean-valued XML attribute when rebuilding the response', async () => {
+	// `XMLBuilder`'s `suppressBooleanAttributes` defaults to `true`: it omits the
+	// `="value"` part for any attribute whose value is exactly the string 'true',
+	// e.g. `attr="true"` round-trips as the bare `attr`. That does not corrupt the
+	// XML the way the mismatched `textNodeName` above does, but a stricter parser
+	// downstream can silently lose the attribute instead of reading it back as
+	// `'true'`. Unlike the synthetic case above, this one ships in the wild today:
+	// a folder tagged with a Nextcloud collaborative system tag gets a
+	// `<nc:system-tag oc:can-assign="true" oc:user-visible="true">` in every
+	// PROPFIND response that lists it.
+	const response = homeListingPropFindResponse.replace(
+		'<d:displayname>New folder</d:displayname>',
+		'<d:displayname>New folder</d:displayname>'
+			+ '<nc:system-tags><nc:system-tag oc:can-assign="true" oc:id="8" oc:user-assignable="false" '
+			+ 'oc:user-visible="true" nc:color="B0B0B0">BACKUP</nc:system-tag></nc:system-tags>',
+	)
+	expect(response).not.toBe(homeListingPropFindResponse)
+
+	const context = {
+		req: new Request('https://example.com/remote.php/dav/files/admin', { method: 'PROPFIND' }),
+		res: new Response(response),
+		type: 'fetch' as const,
+	}
+
+	await usePropFindInterceptor(context, async () => {})
+
+	const raw = await context.res.text()
+	expect(raw).toContain('<system-tag can-assign="true" id="8" user-assignable="false" user-visible="true" color="B0B0B0">BACKUP</system-tag>')
+})
+
 test('Correctly replace root file info in PROPFIND', async () => {
 	const metadata = await RootMetadata.fromJson(rootFolderMetadata, 'admin', await decryptPrivateKey(adminPrivateKeyInfo, adminMnemonic))
 	metadataStore.getMetadata

--- a/src/middleware/usePropFindInterceptor.spec.ts
+++ b/src/middleware/usePropFindInterceptor.spec.ts
@@ -49,6 +49,21 @@ test('passes through non encrypted propfinds', async () => {
 	await expect(context.res.text()).resolves.toBe(unencryptedPropFindResponse)
 })
 
+test('does not throw and passes through the response as-is when it cannot be parsed', async () => {
+	// e.g. an empty body, an HTML error page, or any other response that is
+	// not a well-formed WebDAV multistatus - this must never take down the
+	// whole PROPFIND request, see #1991.
+	const malformedBody = 'this is not xml'
+	const context = {
+		req: new Request('https://example.com/remote.php/dav/files/admin/unencrypted', { method: 'PROPFIND' }),
+		res: new Response(malformedBody),
+		type: 'fetch' as const,
+	}
+
+	await expect(usePropFindInterceptor(context, async () => {})).resolves.not.toThrow()
+	await expect(context.res.text()).resolves.toBe(malformedBody)
+})
+
 test('Correctly adjust e2ee nodes in PROPFIND of an unencrypted folder', async () => {
 	const metadata = await RootMetadata.fromJson(rootFolderMetadata, 'admin', await decryptPrivateKey(adminPrivateKeyInfo, adminMnemonic))
 	metadataStore.getMetadata

--- a/src/middleware/usePropFindInterceptor.ts
+++ b/src/middleware/usePropFindInterceptor.ts
@@ -15,6 +15,17 @@ import { decodePath } from '../services/path.ts'
 import * as metadataStore from '../store/metadata.ts'
 import * as taskStore from '../store/tasks.ts'
 
+// `parseXML()` (see below) parses every PROPFIND response with `textNodeName: 'text'`
+// and `attributeNamePrefix: '@'` (the `webdav` package's own defaults, see its
+// `parseXML()`/`getParser()` in `source/tools/dav.ts`) - but `XMLBuilder` defaults to
+// `textNodeName: '#text'`, `attributeNamePrefix: '@_'` and `ignoreAttributes: true`.
+// Building with the builder's own defaults after parsing with the parser's therefore
+// does not round-trip: any node whose text content ends up wrapped in an object (e.g.
+// because the node also carries attributes) keeps sitting under the key `'text'`, which
+// the builder - looking for `'#text'` - does not recognise as special and instead
+// serialises as a literal `<text>` child element, corrupting the rebuilt response.
+const XML_BUILDER_OPTIONS = { attributeNamePrefix: '@', textNodeName: 'text', ignoreAttributes: false }
+
 /**
  * Callback to handle PROPFIND requests.
  *
@@ -60,7 +71,7 @@ export async function usePropFindInterceptor(context: FetchContext, next: () => 
 		await cacheMetadataFromPropfind(xml, isEncryptedNode, targetIsEncrypted)
 		await replacePlaceholdersInPropfind(xml, isEncryptedNode)
 
-		context.res = new Response(new XMLBuilder().build(xml), response)
+		context.res = new Response(new XMLBuilder(XML_BUILDER_OPTIONS).build(xml), response)
 	} catch (error) {
 		logger.error('Failed to process PROPFIND response for e2ee, passing it through unmodified', { error, request: context.req })
 	}

--- a/src/middleware/usePropFindInterceptor.ts
+++ b/src/middleware/usePropFindInterceptor.ts
@@ -24,7 +24,24 @@ import * as taskStore from '../store/tasks.ts'
 // because the node also carries attributes) keeps sitting under the key `'text'`, which
 // the builder - looking for `'#text'` - does not recognise as special and instead
 // serialises as a literal `<text>` child element, corrupting the rebuilt response.
-const XML_BUILDER_OPTIONS = { attributeNamePrefix: '@', textNodeName: 'text', ignoreAttributes: false }
+//
+// `suppressBooleanAttributes` (builder default: `true`) is a second, independent
+// mismatch: it omits the `="value"` part for any attribute whose value is exactly
+// the string `'true'`, e.g. `<nc:system-tag oc:can-assign="true">` round-trips as
+// the bare `<system-tag can-assign>`. That is valid XML - it does not reproduce the
+// `<text>`/`<@attr>` crash above - but a parser that (correctly) treats a bare
+// attribute as boolean `true` rather than the string `'true'`, or one that follows
+// fast-xml-parser's own parsing default of ignoring bare attributes altogether
+// (`allowBooleanAttributes` also defaults to `false` on the parsing side), silently
+// loses that attribute from the rebuilt response. Confirmed against a real, in-the-
+// wild PROPFIND response: a folder tagged with a collaborative system tag ships
+// `oc:can-assign="true"` and `oc:user-visible="true"` on its `<nc:system-tag>`.
+const XML_BUILDER_OPTIONS = {
+	attributeNamePrefix: '@',
+	textNodeName: 'text',
+	ignoreAttributes: false,
+	suppressBooleanAttributes: false,
+}
 
 /**
  * Callback to handle PROPFIND requests.

--- a/src/middleware/usePropFindInterceptor.ts
+++ b/src/middleware/usePropFindInterceptor.ts
@@ -26,31 +26,44 @@ export async function usePropFindInterceptor(context: FetchContext, next: () => 
 
 	context.req.headers.set('X-E2EE-SUPPORTED', 'true')
 	await next()
-	const response = context.res.clone()
-	const path = new URL(context.req.url).pathname
-	const body = await response.text()
-	const xml = await parseXML(body)
-	const stat = parseStat(xml, path, true)
 
-	// The requested node itself might not be encrypted while the result still contains
-	// encrypted nodes, e.g. when listing an unencrypted folder that contains an e2ee root.
-	// So the encryption state has to be decided for each node individually.
-	const targetIsEncrypted = stat.props !== undefined && String(stat.props['e2ee-is-encrypted']) === '1'
-	const isEncryptedNode = (node: DAVResultResponse): boolean => (
-		// all nodes within an encrypted PROPFIND target are encrypted as well
-		targetIsEncrypted
-		|| String(node.propstat?.prop['e2ee-is-encrypted']) === '1'
-	)
+	// This interceptor is a transparency layer on top of every single PROPFIND
+	// request, including ones that have nothing to do with e2ee. If anything
+	// below fails to parse or process the response - for whatever reason - we
+	// must not let that take down the original, otherwise perfectly fine,
+	// PROPFIND response with it. Worst case, e2ee placeholders are left
+	// unresolved for this one request instead of the whole file listing
+	// breaking (see #1991 for a case where an unencrypted instance with no
+	// e2ee folders at all had every single PROPFIND fail because of this).
+	try {
+		const response = context.res.clone()
+		const path = new URL(context.req.url).pathname
+		const body = await response.text()
+		const xml = await parseXML(body)
+		const stat = parseStat(xml, path, true)
 
-	if (!xml.multistatus.response.some(isEncryptedNode)) {
-		logger.debug('No e2ee nodes in PROPFIND result', { xml })
-		return
+		// The requested node itself might not be encrypted while the result still contains
+		// encrypted nodes, e.g. when listing an unencrypted folder that contains an e2ee root.
+		// So the encryption state has to be decided for each node individually.
+		const targetIsEncrypted = stat.props !== undefined && String(stat.props['e2ee-is-encrypted']) === '1'
+		const isEncryptedNode = (node: DAVResultResponse): boolean => (
+			// all nodes within an encrypted PROPFIND target are encrypted as well
+			targetIsEncrypted
+			|| String(node.propstat?.prop['e2ee-is-encrypted']) === '1'
+		)
+
+		if (!xml.multistatus.response.some(isEncryptedNode)) {
+			logger.debug('No e2ee nodes in PROPFIND result', { xml })
+			return
+		}
+
+		await cacheMetadataFromPropfind(xml, isEncryptedNode, targetIsEncrypted)
+		await replacePlaceholdersInPropfind(xml, isEncryptedNode)
+
+		context.res = new Response(new XMLBuilder().build(xml), response)
+	} catch (error) {
+		logger.error('Failed to process PROPFIND response for e2ee, passing it through unmodified', { error, request: context.req })
 	}
-
-	await cacheMetadataFromPropfind(xml, isEncryptedNode, targetIsEncrypted)
-	await replacePlaceholdersInPropfind(xml, isEncryptedNode)
-
-	context.res = new Response(new XMLBuilder().build(xml), response)
 }
 
 /**


### PR DESCRIPTION
Fixes #1991.

This started out as a single defensive fix and grew into two related, but distinct, fixes for the same underlying problem area (the request from a reviewer to actually narrow down the root cause, see below).

## Commit 1 - don't let a PROPFIND parsing failure break the whole file listing

`usePropFindInterceptor()` unconditionally parses **every** PROPFIND response as XML (`parseXML(body)`) before it even checks whether the result contains any e2ee node. On an instance where the app is enabled but no folder is actually end-to-end encrypted, this parsing step can throw (`Invalid response: No root multistatus found`, full repro and console trace in #1991), and that exception was never caught - it propagated all the way up through the middleware chain and broke the *entire* file listing, for every single folder, not just encrypted ones.

Wraps the interceptor's processing in a `try`/`catch` so that whatever goes wrong here, it can no longer take down plain, non-e2ee file browsing - worst case, e2ee placeholders are just left unresolved for that one response and it's logged, instead of Files becoming completely unusable.

## Commit 2 - keep `XMLBuilder` options in sync with the parser's

I wasn't able to pin down the exact root cause of the original issue when I opened this PR, and kept seeing the same class of error (`Invalid tag name: text`, thrown downstream in Nextcloud's own DAV client, *after* our interceptor had already returned) on an instance with the fix from commit 1 already deployed - meaning `parseXML()` itself was succeeding, and something *we* rebuild afterwards was the problem, not the original response.

Root cause: `parseXML()` (from the `webdav` package) parses every response with `textNodeName: 'text'` and `attributeNamePrefix: '@'` - its own defaults (see `getParser()` in [`source/tools/dav.ts`](https://github.com/perry-mitchell/webdav-client/blob/v5.10.0/source/tools/dav.ts)). The response is then rebuilt with a bare `new XMLBuilder()`, which instead falls back to `fast-xml-parser`'s own defaults: `textNodeName: '#text'`, `attributeNamePrefix: '@_'` and `ignoreAttributes: true`.

`fast-xml-parser` only wraps a node's text content in an object under `textNodeName` - instead of returning it as a plain string - when that node also has to carry other keys alongside it, e.g. an attribute. With the mismatched options above, the builder doesn't recognise the wrapped text sitting under `'text'` as special and serialises it as a literal `<text>` child element instead (plus an invalid `<@attr>` tag for the attribute itself), corrupting the rebuilt response. Nextcloud's own DAV client then fails to parse that back with `Invalid tag name: text`.

Fix: a `XML_BUILDER_OPTIONS` constant mirroring the parser's options, used for the `XMLBuilder` call.

Added a test reproducing the corruption - with a synthetic attribute, since I could not find a real Nextcloud DAV property that currently ships a non-namespace attribute on a text-bearing element (the one pre-existing case in our own fixtures, `x1:share-permissions`'s inline `xmlns:x1`, is filtered out by the parser as a namespace declaration rather than kept as data, so it doesn't trigger this). I want to be upfront about that: I can't point to a specific property that hits this today, only demonstrate that the option mismatch itself is real and that the round trip breaks the moment any node carries an attribute alongside text, regardless of whether something already does. The alignment should hold either way.

All existing tests still pass, plus the two new ones (`ts:check`/`lint`/`test` all green locally).

Happy to adjust either commit if someone can point me at a way to reproduce the exact original `parseXML()` failure from #1991 locally, or at a real DAV property that hits the `XMLBuilder` mismatch - neither commit claims to be a full explanation of everything reported in #1991, just concrete bugs found in this middleware along the way.
