### PR TITLE
fix: handle filesystem root in encrypted file checks

### DIFF
--- a/lib/EncryptionManager.php
+++ b/lib/EncryptionManager.php
@@ -65,8 +65,6 @@ class EncryptionManager {
 
 	/**
 	 * Check if a file is in a folder marked as encrypted.
-	 *
-	 * The filesystem root is not an encrypted file or folder, so it returns false.
 	 */
 	public static function isEncryptedFile(Node $node): bool {
 		// traverse up if node is not a folder to prevent false positives for SSE files

--- a/lib/EncryptionManager.php
+++ b/lib/EncryptionManager.php
@@ -64,7 +64,9 @@ class EncryptionManager {
 	}
 
 	/**
-	 * Check if a file is in a folder marked as encrypted
+	 * Check if a file is in a folder marked as encrypted.
+	 *
+	 * The filesystem root is not an encrypted file or folder, so it returns false.
 	 */
 	public static function isEncryptedFile(Node $node): bool {
 		// traverse up if node is not a folder to prevent false positives for SSE files
@@ -73,12 +75,12 @@ class EncryptionManager {
 			$node = $node->getParent();
 		}
 
-		do {
+		while ($node->getPath() !== '/') {
 			if ($node->isEncrypted()) {
 				return true;
 			}
 			$node = $node->getParent();
-		} while ($node->getPath() !== '/');
+		}
 
 		return false;
 	}
@@ -87,7 +89,7 @@ class EncryptionManager {
 	 * Check if file ID points to a valid folder
 	 * @throws NotFoundException
 	 */
-	protected function isValidFolder(int $id):void {
+	protected function isValidFolder(int $id): void {
 		$this->accessManager->checkPermissions($id, true);
 		$node = $this->rootFolder->getFirstNodeById($id);
 		if (!$node instanceof Folder) {


### PR DESCRIPTION
If the root node itself were passed (admittedly unusual), the existing implementation would indirectly throw since `Root::getParent()` throws `NotFoundException`, because the filesystem root has no parent and  the `do` loop executes unconditionally.

This defensive edge-case fix better aligns the implementation with the `getParent()` contract while treating the root as a 
normal negative result, which is consistent with what the existing code implied as the intended behavior.

Change: Avoid calling `getParent()` when already at the filesystem root. 

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
