### PR TITLE
fix: clean up legacy metadata when deleting files

### DIFF
--- a/lib/MetaDataStorage.php
+++ b/lib/MetaDataStorage.php
@@ -138,9 +138,6 @@ class MetaDataStorage implements IMetaDataStorage {
 		$this->getTokenFolder($token)->newFile("$id", '');
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function deleteMetaData(string $userId, int $id): void {
 		$this->verifyFolderStructure();
 		$this->verifyOwner($userId, $id);
@@ -149,6 +146,8 @@ class MetaDataStorage implements IMetaDataStorage {
 		try {
 			$dir = $this->appData->getFolder($folderName);
 		} catch (NotFoundException) {
+			// Metadata may exist only in the legacy location.
+			$this->cleanupLegacyFile($userId, $id);
 			return;
 		}
 

--- a/lib/MetaDataStorageV1.php
+++ b/lib/MetaDataStorageV1.php
@@ -123,9 +123,6 @@ class MetaDataStorageV1 implements IMetaDataStorageV1 {
 			->putContent($fileKey);
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function deleteMetaData(string $userId, int $id): void {
 		$this->verifyFolderStructure();
 		$this->verifyOwner($userId, $id);
@@ -134,6 +131,8 @@ class MetaDataStorageV1 implements IMetaDataStorageV1 {
 		try {
 			$dir = $this->appData->getFolder($folderName);
 		} catch (NotFoundException) {
+			// Metadata may exist only in the legacy location.
+			$this->cleanupLegacyFile($userId, $id);
 			return;
 		}
 

--- a/tests/Unit/MetaDataStorageTest.php
+++ b/tests/Unit/MetaDataStorageTest.php
@@ -356,11 +356,17 @@ class MetaDataStorageTest extends TestCase {
 		$metaDataStorage->expects($this->once())
 			->method('verifyOwner')
 			->with('userId', 42);
+
 		$metaDataStorage->expects($this->once())
 			->method('verifyFolderStructure');
 
+		$metaDataStorage->expects($this->once())
+			->method('cleanupLegacyFile')
+			->with('userId', 42);
+
 		if ($folderExists) {
 			$metaDataFolder = $this->createMock(ISimpleFolder::class);
+
 			$this->appData->expects($this->once())
 				->method('getFolder')
 				->with('/meta-data/42')
@@ -368,9 +374,6 @@ class MetaDataStorageTest extends TestCase {
 
 			$metaDataFolder->expects($this->once())
 				->method('delete');
-			$metaDataStorage->expects($this->once())
-				->method('cleanupLegacyFile')
-				->with('userId', 42);
 		} else {
 			$this->appData->expects($this->once())
 				->method('getFolder')

--- a/tests/Unit/MetaDataStorageV1Test.php
+++ b/tests/Unit/MetaDataStorageV1Test.php
@@ -335,11 +335,17 @@ class MetaDataStorageV1Test extends TestCase {
 		$metaDataStorage->expects($this->once())
 			->method('verifyOwner')
 			->with('userId', 42);
+
 		$metaDataStorage->expects($this->once())
 			->method('verifyFolderStructure');
 
+		$metaDataStorage->expects($this->once())
+			->method('cleanupLegacyFile')
+			->with('userId', 42);
+
 		if ($folderExists) {
 			$metaDataFolder = $this->createMock(ISimpleFolder::class);
+
 			$this->appData->expects($this->once())
 				->method('getFolder')
 				->with('/meta-data/42')
@@ -347,9 +353,6 @@ class MetaDataStorageV1Test extends TestCase {
 
 			$metaDataFolder->expects($this->once())
 				->method('delete');
-			$metaDataStorage->expects($this->once())
-				->method('cleanupLegacyFile')
-				->with('userId', 42);
 		} else {
 			$this->appData->expects($this->once())
 				->method('getFolder')


### PR DESCRIPTION
Legacy metadata (#179)  is stored using the file's historical filesystem path rather than its file ID. 

If a file is deleted before its metadata is migrated to the modern ID-based layout, the modern metadata folder may not exist. In that case, `deleteMetaData()` currently returns early and leaves the legacy metadata orphaned in app data.

This change ensures that legacy metadata cleanup is also  performed when the modern metadata folder is absent.

Updated the unit test to verify that legacy cleanup is invoked both when the modern metadata folder exists and when it is missing.

Edit: I guess this may need to be done for the v1 api separately...

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
