### PR TITLE
fix: delete stale intermediate metadata signatures after rollback

### DIFF
--- a/lib/MetaDataStorage.php
+++ b/lib/MetaDataStorage.php
@@ -243,9 +243,6 @@ class MetaDataStorage implements IMetaDataStorage {
 		}
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function deleteIntermediateFile(string $userId, int $id): void {
 		$this->verifyFolderStructure();
 		$this->verifyOwner($userId, $id);
@@ -264,6 +261,11 @@ class MetaDataStorage implements IMetaDataStorage {
 
 		if ($dir->fileExists($this->intermediateMetaDataCounterFileName)) {
 			$dir->getFile($this->intermediateMetaDataCounterFileName)
+				->delete();
+		}
+
+		if ($dir->fileExists($this->intermediateMetaDataSignatureFileName)) {
+			$dir->getFile($this->intermediateMetaDataSignatureFileName)
 				->delete();
 		}
 	}

--- a/lib/MetaDataStorage.php
+++ b/lib/MetaDataStorage.php
@@ -242,9 +242,6 @@ class MetaDataStorage implements IMetaDataStorage {
 		}
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function deleteIntermediateFile(string $userId, int $id): void {
 		$this->verifyFolderStructure();
 		$this->verifyOwner($userId, $id);
@@ -263,6 +260,11 @@ class MetaDataStorage implements IMetaDataStorage {
 
 		if ($dir->fileExists($this->intermediateMetaDataCounterFileName)) {
 			$dir->getFile($this->intermediateMetaDataCounterFileName)
+				->delete();
+		}
+
+		if ($dir->fileExists($this->intermediateMetaDataSignatureFileName)) {
+			$dir->getFile($this->intermediateMetaDataSignatureFileName)
 				->delete();
 		}
 	}

--- a/lib/MetaDataStorageV1.php
+++ b/lib/MetaDataStorageV1.php
@@ -29,6 +29,8 @@ class MetaDataStorageV1 implements IMetaDataStorageV1 {
 	private string $metaDataRoot = '/meta-data';
 	private string $metaDataFileName = 'meta.data';
 	private string $intermediateMetaDataFileName = 'intermediate.meta.data';
+	private string $intermediateMetaDataSignatureFileName = 'intermediate.meta.data.signature';
+	private string $intermediateMetaDataCounterFileName = 'intermediate.meta.data.counter';
 
 	public function __construct(IAppData $appData,
 		IRootFolder $rootFolder) {
@@ -177,9 +179,6 @@ class MetaDataStorageV1 implements IMetaDataStorageV1 {
 		$this->cleanupLegacyFile($userId, $id);
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function deleteIntermediateFile(string $userId, int $id): void {
 		$this->verifyFolderStructure();
 		$this->verifyOwner($userId, $id);
@@ -191,12 +190,20 @@ class MetaDataStorageV1 implements IMetaDataStorageV1 {
 			return;
 		}
 
-		if (!$dir->fileExists($this->intermediateMetaDataFileName)) {
-			return;
+		if ($dir->fileExists($this->intermediateMetaDataFileName)) {
+			$dir->getFile($this->intermediateMetaDataFileName)
+				->delete();
 		}
 
-		$dir->getFile($this->intermediateMetaDataFileName)
-			->delete();
+		if ($dir->fileExists($this->intermediateMetaDataCounterFileName)) {
+			$dir->getFile($this->intermediateMetaDataCounterFileName)
+				->delete();
+		}
+
+		if ($dir->fileExists($this->intermediateMetaDataSignatureFileName)) {
+			$dir->getFile($this->intermediateMetaDataSignatureFileName)
+				->delete();
+		}
 	}
 
 	private function getFolderNameForFileId(int $id): string {

--- a/tests/Unit/MetaDataStorageTest.php
+++ b/tests/Unit/MetaDataStorageTest.php
@@ -588,7 +588,9 @@ class MetaDataStorageTest extends TestCase {
 			$metaDataFolder->expects($this->exactly(2))
 				->method('fileExists')
 				->willReturnCallback(fn (string $name): bool => match ($name) {
-					'intermediate.meta.data', 'intermediate.meta.data.counter' => $fileExists,
+					'intermediate.meta.data',
+					'intermediate.meta.data.counter',
+					'intermediate.meta.data.signature' => $fileExists,
 				});
 
 			if ($fileExists) {
@@ -600,11 +602,16 @@ class MetaDataStorageTest extends TestCase {
 				$intermediateCounterFile->expects($this->once())
 					->method('delete');
 
+				$intermediateSignatureFile = $this->createMock(ISimpleFile::class);
+				$intermediateSignatureFile->expects($this->once())
+					->method('delete');
+
 				$metaDataFolder->expects($this->exactly(2))
 					->method('getFile')
 					->willReturnCallback(fn (string $name): ISimpleFile => match ($name) {
 						'intermediate.meta.data' => $intermediateFile,
 						'intermediate.meta.data.counter' => $intermediateCounterFile,
+						'intermediate.meta.data.signature' => $intermediateSignatureFile,
 					});
 			}
 		}

--- a/tests/Unit/MetaDataStorageTest.php
+++ b/tests/Unit/MetaDataStorageTest.php
@@ -585,7 +585,7 @@ class MetaDataStorageTest extends TestCase {
 				->with('/meta-data/42')
 				->willReturn($metaDataFolder);
 
-			$metaDataFolder->expects($this->exactly(2))
+			$metaDataFolder->expects($this->exactly(3))
 				->method('fileExists')
 				->willReturnCallback(fn (string $name): bool => match ($name) {
 					'intermediate.meta.data',
@@ -606,7 +606,7 @@ class MetaDataStorageTest extends TestCase {
 				$intermediateSignatureFile->expects($this->once())
 					->method('delete');
 
-				$metaDataFolder->expects($this->exactly(2))
+				$metaDataFolder->expects($this->exactly(3))
 					->method('getFile')
 					->willReturnCallback(fn (string $name): ISimpleFile => match ($name) {
 						'intermediate.meta.data' => $intermediateFile,

--- a/tests/Unit/MetaDataStorageTest.php
+++ b/tests/Unit/MetaDataStorageTest.php
@@ -588,7 +588,7 @@ class MetaDataStorageTest extends TestCase {
 				->with('/meta-data/42')
 				->willReturn($metaDataFolder);
 
-			$metaDataFolder->expects($this->exactly(2))
+			$metaDataFolder->expects($this->exactly(3))
 				->method('fileExists')
 				->willReturnCallback(fn (string $name): bool => match ($name) {
 					'intermediate.meta.data',
@@ -609,7 +609,7 @@ class MetaDataStorageTest extends TestCase {
 				$intermediateSignatureFile->expects($this->once())
 					->method('delete');
 
-				$metaDataFolder->expects($this->exactly(2))
+				$metaDataFolder->expects($this->exactly(3))
 					->method('getFile')
 					->willReturnCallback(fn (string $name): ISimpleFile => match ($name) {
 						'intermediate.meta.data' => $intermediateFile,

--- a/tests/Unit/MetaDataStorageTest.php
+++ b/tests/Unit/MetaDataStorageTest.php
@@ -591,7 +591,9 @@ class MetaDataStorageTest extends TestCase {
 			$metaDataFolder->expects($this->exactly(2))
 				->method('fileExists')
 				->willReturnCallback(fn (string $name): bool => match ($name) {
-					'intermediate.meta.data', 'intermediate.meta.data.counter' => $fileExists,
+					'intermediate.meta.data',
+					'intermediate.meta.data.counter',
+					'intermediate.meta.data.signature' => $fileExists,
 				});
 
 			if ($fileExists) {
@@ -603,11 +605,16 @@ class MetaDataStorageTest extends TestCase {
 				$intermediateCounterFile->expects($this->once())
 					->method('delete');
 
+				$intermediateSignatureFile = $this->createMock(ISimpleFile::class);
+				$intermediateSignatureFile->expects($this->once())
+					->method('delete');
+
 				$metaDataFolder->expects($this->exactly(2))
 					->method('getFile')
 					->willReturnCallback(fn (string $name): ISimpleFile => match ($name) {
 						'intermediate.meta.data' => $intermediateFile,
 						'intermediate.meta.data.counter' => $intermediateCounterFile,
+						'intermediate.meta.data.signature' => $intermediateSignatureFile,
 					});
 			}
 		}

--- a/tests/Unit/MetaDataStorageV1Test.php
+++ b/tests/Unit/MetaDataStorageV1Test.php
@@ -507,20 +507,34 @@ class MetaDataStorageV1Test extends TestCase {
 				->with('/meta-data/42')
 				->willReturn($metaDataFolder);
 
-			$metaDataFolder->expects($this->once())
+			$metaDataFolder->expects($this->exactly(3))
 				->method('fileExists')
-				->with('intermediate.meta.data')
-				->willReturn($fileExists);
+				->willReturnCallback(fn (string $name): bool => match ($name) {
+					'intermediate.meta.data',
+					'intermediate.meta.data.counter',
+					'intermediate.meta.data.signature' => $fileExists,
+				});
 
 			if ($fileExists) {
 				$intermediateFile = $this->createMock(ISimpleFile::class);
 				$intermediateFile->expects($this->once())
 					->method('delete');
 
-				$metaDataFolder->expects($this->once())
+				$intermediateCounterFile = $this->createMock(ISimpleFile::class);
+				$intermediateCounterFile->expects($this->once())
+					->method('delete');
+
+				$intermediateSignatureFile = $this->createMock(ISimpleFile::class);
+				$intermediateSignatureFile->expects($this->once())
+					->method('delete');
+
+				$metaDataFolder->expects($this->exactly(3))
 					->method('getFile')
-					->with('intermediate.meta.data')
-					->willReturn($intermediateFile);
+					->willReturnCallback(fn (string $name): ISimpleFile => match ($name) {
+						'intermediate.meta.data' => $intermediateFile,
+						'intermediate.meta.data.counter' => $intermediateCounterFile,
+						'intermediate.meta.data.signature' => $intermediateSignatureFile,
+					});
 			}
 		}
 


### PR DESCRIPTION
`deleteIntermediateFile()` removed the intermediate metadata and counter files, but left the intermediate signature file behind. This could leave a stale signature in the metadata folder.

In addition to being a cleanup oversight, this could, in some scenarios, result in a stale intermediate sig later being promoted to the final metadata sig. 

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
