### PR TITLE
fix: add 2.1 metadata version support to "legacy" models.ts

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -40,7 +40,7 @@ export type Metadata = {
 	}
 	users?: UserWithAccess[]
 	filedrop?: Record<string, FileDropEntry>
-	version: '2.0'
+	version: '2.0' | '2.1'
 }
 
 export type RootMetadata = Metadata & {


### PR DESCRIPTION
Until #2035 can be more broadly addressed, this change at least aligns things.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
