### PR TITLE
refactor(metadata): add a shared backend version helper 

### DIFF
--- a/lib/MetaDataStorage.php
+++ b/lib/MetaDataStorage.php
@@ -227,15 +227,7 @@ class MetaDataStorage implements IMetaDataStorage {
 			$metadata = $dir->getFile($this->metaDataFileName)->getContent();
 			$decodedMetadata = json_decode($metadata, true);
 
-			if ($decodedMetadata['metadata']['version'] === '1.2') {
-				return '';
-			}
-
-			if ($decodedMetadata['metadata']['version'] === 1.2) {
-				return '';
-			}
-
-			if ($decodedMetadata['metadata']['version'] === 1) {
+			if (MetaDataVersion::isV1($decodedMetadata['metadata']['version'])) {
 				return '';
 			}
 

--- a/lib/MetaDataStorage.php
+++ b/lib/MetaDataStorage.php
@@ -226,15 +226,7 @@ class MetaDataStorage implements IMetaDataStorage {
 			$metadata = $dir->getFile($this->metaDataFileName)->getContent();
 			$decodedMetadata = json_decode($metadata, true);
 
-			if ($decodedMetadata['metadata']['version'] === '1.2') {
-				return '';
-			}
-
-			if ($decodedMetadata['metadata']['version'] === 1.2) {
-				return '';
-			}
-
-			if ($decodedMetadata['metadata']['version'] === 1) {
+			if (MetaDataVersion::isV1($decodedMetadata['metadata']['version'])) {
 				return '';
 			}
 

--- a/lib/MetaDataStorageV1.php
+++ b/lib/MetaDataStorageV1.php
@@ -298,9 +298,10 @@ class MetaDataStorageV1 implements IMetaDataStorageV1 {
 		$metadata = $this->getMetadata($userId, $id);
 		$decodedMetadata = json_decode($metadata, true);
 
-		return match ($decodedMetadata['metadata']['version']) {
-			'1.2', 1.2, 1 => true,
-			default => throw new NotPermittedException('Use the v2 endpoint for this file'),
-		};
+		if (MetaDataVersion::isV1($decodedMetadata['metadata']['version'])) {
+			return true;
+		}
+
+		throw new NotPermittedException('Use the v2 endpoint for this file');
 	}
 }

--- a/lib/MetaDataStorageV1.php
+++ b/lib/MetaDataStorageV1.php
@@ -297,9 +297,10 @@ class MetaDataStorageV1 implements IMetaDataStorageV1 {
 		$metadata = $this->getMetadata($userId, $id);
 		$decodedMetadata = json_decode($metadata, true);
 
-		return match ($decodedMetadata['metadata']['version']) {
-			'1.2', 1.2, 1 => true,
-			default => throw new NotPermittedException('Use the v2 endpoint for this file'),
-		};
+		if (MetaDataVersion::isV1($decodedMetadata['metadata']['version'])) {
+			return true;
+		}
+
+		throw new NotPermittedException('Use the v2 endpoint for this file');
 	}
 }

--- a/lib/MetaDataVersion.php
+++ b/lib/MetaDataVersion.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OCA\EndToEndEncryption;
 
-final class MetadataVersion {
+final class MetaDataVersion {
 	/**
 	 * These are the legacy values emitted by v1 clients.
 	 *

--- a/lib/MetaDataVersion.php
+++ b/lib/MetaDataVersion.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EndToEndEncryption;
+
+final class MetadataVersion {
+	/**
+	 * These are the legacy values emitted by v1 clients.
+	 *
+	 * The strict comparison is intentional:
+	 * - 1       is supported
+	 * - 1.2     is supported
+	 * - '1.2'   is supported
+	 * - '1'     is not silently treated as a supported legacy value
+	 *
+	 * @var list<int|float|string>
+	 */
+	private const LEGACY_V1_VERSIONS = [1, 1.2, '1.2'];
+
+	public static function isV1(mixed $version): bool {
+		return in_array($version, self::LEGACY_V1_VERSIONS, true);
+	}
+}

--- a/lib/MetaDataVersion.php
+++ b/lib/MetaDataVersion.php
@@ -1,6 +1,10 @@
 <?php
 
 declare(strict_types=1);
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 
 namespace OCA\EndToEndEncryption;
 
@@ -16,7 +20,7 @@ final class MetaDataVersion {
 	 *
 	 * @var list<int|float|string>
 	 */
-	private const LEGACY_V1_VERSIONS = [1, 1.2, '1.2'];
+	private const array LEGACY_V1_VERSIONS = [1, 1.2, '1.2'];
 
 	public static function isV1(mixed $version): bool {
 		return in_array($version, self::LEGACY_V1_VERSIONS, true);

--- a/lib/Middleware/ClientHasCapabilityMiddleware.php
+++ b/lib/Middleware/ClientHasCapabilityMiddleware.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\EndToEndEncryption\Middleware;
 
 use OCA\EndToEndEncryption\IMetaDataStorage;
+use OCA\EndToEndEncryption\MetaDataVersion;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\IRequest;
@@ -48,15 +49,7 @@ class ClientHasCapabilityMiddleware extends Middleware {
 		$metadata = $this->metadataStorage->getMetaData($this->userId ?? '', (int)$fileId);
 		$decodedMetadata = json_decode($metadata, true);
 
-		if ($decodedMetadata['metadata']['version'] === 1) {
-			return;
-		}
-
-		if ($decodedMetadata['metadata']['version'] === '1.2') {
-			return;
-		}
-
-		if ($decodedMetadata['metadata']['version'] === 1.2) {
+		if (MetaDataVersion::isV1($decodedMetadata['metadata']['version'])) {
 			return;
 		}
 

--- a/lib/Middleware/ClientHasCapabilityMiddleware.php
+++ b/lib/Middleware/ClientHasCapabilityMiddleware.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\EndToEndEncryption\Middleware;
 
 use OCA\EndToEndEncryption\IMetaDataStorage;
+use OCA\EndToEndEncryption\MetaDataVersion;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\Files\NotFoundException;
@@ -56,15 +57,7 @@ class ClientHasCapabilityMiddleware extends Middleware {
 
 		$decodedMetadata = json_decode($metadata, true);
 
-		if ($decodedMetadata['metadata']['version'] === 1) {
-			return;
-		}
-
-		if ($decodedMetadata['metadata']['version'] === '1.2') {
-			return;
-		}
-
-		if ($decodedMetadata['metadata']['version'] === 1.2) {
+		if (MetaDataVersion::isV1($decodedMetadata['metadata']['version'])) {
 			return;
 		}
 

--- a/tests/Unit/MetaDataVersionTest.php
+++ b/tests/Unit/MetaDataVersionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\EndToEndEncryption\Tests\Unit;
+
+use OCA\EndToEndEncryption\MetaDataVersion;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Test\TestCase;
+
+class MetaDataVersionTest extends TestCase {
+	#[DataProvider('v1VersionsProvider')]
+	public function testV1Versions(mixed $version): void {
+		$this->assertTrue(MetaDataVersion::isV1($version));
+	}
+
+	/**
+	 * @return list<array{mixed}>
+	 */
+	public static function v1VersionsProvider(): array {
+		return [
+			[1],
+			[1.2],
+			['1.2'],
+		];
+	}
+
+	#[DataProvider('unsupportedVersionsProvider')]
+	public function testUnsupportedVersions(mixed $version): void {
+		$this->assertFalse(MetaDataVersion::isV1($version));
+	}
+
+	/**
+	 * @return list<array{mixed}>
+	 */
+	public static function unsupportedVersionsProvider(): array {
+		return [
+			['1'],
+			['2.0'],
+			['2.1'],
+			[2.0],
+			[null],
+		];
+	}
+}

--- a/tests/Unit/MetaDataVersionTest.php
+++ b/tests/Unit/MetaDataVersionTest.php
@@ -1,6 +1,10 @@
 <?php
 
 declare(strict_types=1);
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 
 namespace OCA\EndToEndEncryption\Tests\Unit;
 


### PR DESCRIPTION
Centralize the existing legacy v1 check used by:

- `MetaDataStorage::readSignature()`
- `MetaDataStorageV1::assertMetadataIsV1()`
- `ClientHasCapabilityMiddleware`

No behavior change.

Only for the V1 API to start, since V2 API isn't enforced as strongly on the backend currently.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
