### PR TITLE
fix(dav): multistatus response with property-level 404s

### DIFF
--- a/lib/Connector/Sabre/PropFindPlugin.php
+++ b/lib/Connector/Sabre/PropFindPlugin.php
@@ -14,6 +14,7 @@ use OCA\DAV\Connector\Sabre\File;
 use OCA\EndToEndEncryption\IMetaDataStorage;
 use OCA\EndToEndEncryption\UserAgentManager;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Sabre\DAV\INode;
@@ -52,7 +53,7 @@ class PropFindPlugin extends APlugin {
 		$this->server->on('propFind', $this->updateProperty(...), 105);
 	}
 
-	public function setE2EEProperties(PropFind $propFind, \Sabre\DAV\INode $node): void {
+	public function setE2EEProperties(PropFind $propFind, INode $node): void {
 		if (!($node instanceof Directory || $node instanceof File)) {
 			return;
 		}
@@ -61,18 +62,32 @@ class PropFindPlugin extends APlugin {
 		if ($node instanceof Directory) {
 			$propFind->handle(self::IS_ENCRYPTED_PROPERTYNAME, fn (): string => $this->isE2EEnabledPath($node) ? '1' : '0');
 
-			$propFind->handle(self::E2EE_METADATA_PROPERTYNAME, function () use ($node) {
-				if ($this->isE2EEnabledPath($node)) {
+			$propFind->handle(self::E2EE_METADATA_PROPERTYNAME, function () use ($node): ?string {
+				if (!$this->isE2EEnabledPath($node)) {
+					return null;
+				}
+
+				try {
 					return $this->metaDataStorage->getMetaData(
 						($this->userSession->getUser() ?? $node->getNode()->getOwner())->getUID(),
 						$node->getId(),
 					);
+				} catch (NotFoundException) {
+					// Leave this property at 404 without failing the complete PROPFIND.
+					return null;
 				}
 			});
 
-			$propFind->handle(self::E2EE_METADATA_SIGNATURE_PROPERTYNAME, function () use ($node) {
-				if ($this->isE2EEnabledPath($node)) {
+			$propFind->handle(self::E2EE_METADATA_SIGNATURE_PROPERTYNAME, function () use ($node): ?string {
+				if (!$this->isE2EEnabledPath($node)) {
+					return null;
+				}
+
+				try {
 					return $this->metaDataStorage->readSignature($node->getId());
+				} catch (NotFoundException) {
+					// Leave this property at 404 without failing the complete PROPFIND.
+					return null;
 				}
 			});
 		}

--- a/tests/Unit/Connector/Sabre/PropFindPluginTest.php
+++ b/tests/Unit/Connector/Sabre/PropFindPluginTest.php
@@ -15,7 +15,9 @@ use OCA\EndToEndEncryption\IMetaDataStorage;
 use OCA\EndToEndEncryption\UserAgentManager;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -76,6 +78,80 @@ class PropFindPluginTest extends TestCase {
 			['propFind', 'setE2EEProperties', 104],
 			['propFind', 'updateProperty', 105],
 		], $calls);
+	}
+
+	public function testMissingMetadataReturnsPropertyNotFound(): void {
+		$user = $this->createStub(IUser::class);
+		$user->method('getUID')->willReturn('john');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$metadataStorage = $this->createMock(IMetaDataStorage::class);
+		$metadataStorage->expects($this->once())
+			->method('getMetaData')
+			->with('john', 42)
+			->willThrowException(new NotFoundException());
+
+		$plugin = $this->getMockBuilder(PropFindPlugin::class)
+			->setConstructorArgs([
+				$this->rootFolder,
+				$this->userSession,
+				$this->userAgentManager,
+				$this->request,
+				$metadataStorage,
+			])
+			->onlyMethods(['isE2EEnabledPath'])
+			->getMock();
+		$plugin->method('isE2EEnabledPath')->willReturn(true);
+
+		$node = $this->createStub(Directory::class);
+		$node->method('getId')->willReturn(42);
+
+		$propFind = new PropFind(
+			'files/john/encrypted',
+			[PropFindPlugin::E2EE_METADATA_PROPERTYNAME],
+		);
+
+		$plugin->setE2EEProperties($propFind, $node);
+
+		$this->assertSame(
+			404,
+			$propFind->getStatus(PropFindPlugin::E2EE_METADATA_PROPERTYNAME),
+		);
+	}
+
+	public function testMissingMetadataSignatureReturnsPropertyNotFound(): void {
+		$metadataStorage = $this->createMock(IMetaDataStorage::class);
+		$metadataStorage->expects($this->once())
+			->method('readSignature')
+			->with(42)
+			->willThrowException(new NotFoundException());
+
+		$plugin = $this->getMockBuilder(PropFindPlugin::class)
+			->setConstructorArgs([
+				$this->rootFolder,
+				$this->userSession,
+				$this->userAgentManager,
+				$this->request,
+				$metadataStorage,
+			])
+			->onlyMethods(['isE2EEnabledPath'])
+			->getMock();
+		$plugin->method('isE2EEnabledPath')->willReturn(true);
+
+		$node = $this->createStub(Directory::class);
+		$node->method('getId')->willReturn(42);
+
+		$propFind = new PropFind(
+			'files/john/encrypted',
+			[PropFindPlugin::E2EE_METADATA_SIGNATURE_PROPERTYNAME],
+		);
+
+		$plugin->setE2EEProperties($propFind, $node);
+
+		$this->assertSame(
+			404,
+			$propFind->getStatus(PropFindPlugin::E2EE_METADATA_SIGNATURE_PROPERTYNAME),
+		);
 	}
 
 	public function testUpdatePropertyIgnoreCalendar(): void {


### PR DESCRIPTION
If storage throws `NotFoundException`, it escapes `PropFind::handle()`. Consequently, Sabre cannot finish constructing the multistatus response and the whole request fails, rather than returning a property-level 404.

This change makes is so that when an E2EE directory metadata lookup throws `NotFoundException`, a property-level 404 is generated instead of aborting the whole request. 

Fixes #1189
Fixes #1723

This change also better aligns the DAV behavior with the OCS API.

Details:

Catches `NotFoundException` (only) inside each metadata property callback and returns null. Sabre’s `PropFind::handle()` then leaves that individual property at HTTP 404 while allowing the overall `PROPFIND` transaction to complete.

Does not catch `NotPermittedException`: an authorization/storage-permission failure may warrant failing the request rather than disguising it as missing metadata.

Also adds test coverage.

- [x] Backport probably

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI [tests]
