### PR TITLE
fix(metadata): defer missing metadata handling to controller

### DIFF
--- a/lib/Middleware/ClientHasCapabilityMiddleware.php
+++ b/lib/Middleware/ClientHasCapabilityMiddleware.php
@@ -45,7 +45,14 @@ class ClientHasCapabilityMiddleware extends Middleware {
 		}
 
 		$fileId = $this->request->getParam('id');
-		$metadata = $this->metadataStorage->getMetaData($this->userId ?? '', (int)$fileId);
+		try {
+			$metadata = $this->metadataStorage->getMetaData($this->userId ?? '', (int)$fileId);
+		} catch (NotFoundException) {
+			// There is no metadata version to validate. Let the controller
+			// handle missing metadata or create the initial metadata.
+			return;
+		}
+
 		$decodedMetadata = json_decode($metadata, true);
 
 		if ($decodedMetadata['metadata']['version'] === 1) {

--- a/lib/Middleware/ClientHasCapabilityMiddleware.php
+++ b/lib/Middleware/ClientHasCapabilityMiddleware.php
@@ -11,6 +11,7 @@ namespace OCA\EndToEndEncryption\Middleware;
 use OCA\EndToEndEncryption\IMetaDataStorage;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\Files\NotFoundException;
 use OCP\IRequest;
 
 /**


### PR DESCRIPTION
The v1 metadata controller correctly translates missing metadata (`NotFoundException`) into `OCSNotFoundException`. However, before the controller runs, `ClientHasCapabilityMiddleware` performs its own metadata read for every v1 metadata request. The middleware does not catch `NotFoundException`. The unhandled middleware exception becomes a 500.

This also explains why the existing controller unit test could correctly expect a 404 while the real HTTP request returned 500: the unit test calls the controller directly and does not execute the middleware chain.

This change makes is so that missing metadata causes the capability middleware to defer to the controller. That allows:

- `GET` to return the controller’s intended 404;
- `POST` to create initial metadata rather than being blocked before the controller;
- any other operations to apply their own established missing-metadata behavior.

Fixes #602

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
