### PR TITLE
fix(webui): keep propstat as xml during interceptor handling

### DIFF
--- a/__tests__/consts.spec.ts
+++ b/__tests__/consts.spec.ts
@@ -280,7 +280,9 @@ export const rootFilePropfindResponse = `<?xml version="1.0"?>
 				<nc:share-attributes>[]</nc:share-attributes>
 				<oc:share-types />
 				<x1:share-permissions xmlns:x1="http://open-collaboration-services.org/ns">19</x1:share-permissions>
-				<nc:system-tags />
+				<nc:system-tags>
+					<nc:system-tag can-assign="true" id="7">Secret</nc:system-tag>
+				</nc:system-tags>
 			</d:prop>
 			<d:status>HTTP/1.1 200 OK</d:status>
 		</d:propstat>

--- a/src/middleware/usePropFindInterceptor.spec.ts
+++ b/src/middleware/usePropFindInterceptor.spec.ts
@@ -70,7 +70,7 @@ test('Correctly adjust e2ee nodes in PROPFIND of an unencrypted folder', async (
 	expect(metadataStore.setRawMetadata).toHaveBeenCalledTimes(1)
 	expect(metadataStore.setRawMetadata).toHaveBeenCalledWith(
 		'/remote.php/dav/files/admin/New folder',
-		89,
+		'89',
 		JSON.stringify(rootFolderMetadata),
 		rootFolderMetadataSignature,
 	)
@@ -138,7 +138,7 @@ test('Correctly replace root file info in PROPFIND', async () => {
 
 	expect(metadataStore.setRawMetadata).toHaveBeenCalledWith(
 		'/remote.php/dav/files/admin/New folder',
-		89,
+		'89',
 		JSON.stringify(rootFolderMetadata),
 		rootFolderMetadataSignature,
 	)
@@ -181,7 +181,7 @@ test('Correctly replace subfolder file info in PROPFIND', async () => {
 
 	expect(metadataStore.setRawMetadata).toHaveBeenCalledWith(
 		'/remote.php/dav/files/admin/New folder/fa666d819a6c4315abba421172f0a0b1',
-		266,
+		'266',
 		JSON.stringify(subFolderMetadata),
 		subFolderMetadataSignature,
 	)
@@ -221,4 +221,33 @@ test('Correctly replace file info in PROPFIND of file', async () => {
 	expect(xml.multistatus.response[0]!.propstat?.prop.displayname).toBe('test.txt')
 	expect(xml.multistatus.response[0]!.propstat?.prop.getcontenttype).toBe('text/plain')
 	expect(xml.multistatus.response[0]!.propstat?.prop.permissions).toBe('GDNVW')
+})
+
+test('Hands everything but the replaced properties on unchanged', async () => {
+	const metadata = await RootMetadata.fromJson(rootFolderMetadata, 'admin', await decryptPrivateKey(adminPrivateKeyInfo, adminMnemonic))
+	metadataStore.getMetadata
+		// @ts-expect-error -- mocking for tests
+		.mockResolvedValue({ metadata, path: '/remote.php/dav/files/admin/New folder' })
+
+	const context = {
+		req: new Request('https://example.com/remote.php/dav/files/admin/New%20folder/ad3b12554e0d4364854ae3e21b170152', { method: 'PROPFIND' }),
+		res: new Response(rootFilePropfindResponse),
+		type: 'fetch' as const,
+	}
+
+	await usePropFindInterceptor(context, async () => {})
+	const body = await context.res.text()
+
+	// namespace prefixes and declarations are kept, including the ones declared on a property
+	expect(body).toContain('<d:multistatus xmlns:d="DAV:"')
+	expect(body).toContain('<x1:share-permissions xmlns:x1="http://open-collaboration-services.org/ns">19</x1:share-permissions>')
+	// properties are allowed to have attributes and children of their own
+	expect(body).toContain('<nc:system-tag can-assign="true" id="7">Secret</nc:system-tag>')
+	// the propstat of the properties the server could not provide is kept as well
+	expect(body).toContain('<d:status>HTTP/1.1 404 Not Found</d:status>')
+	expect(body).toContain('<nc:metadata-blurhash/>')
+	// only the encrypted values are replaced
+	expect(body).toContain('<d:displayname>test.txt</d:displayname>')
+	expect(body).toContain('<d:getcontenttype>text/plain</d:getcontenttype>')
+	expect(body).toContain('<oc:permissions>GDNVW</oc:permissions>')
 })

--- a/src/middleware/usePropFindInterceptor.ts
+++ b/src/middleware/usePropFindInterceptor.ts
@@ -4,12 +4,22 @@
  */
 
 import type { FetchContext } from '@rxliuli/vista'
-import type { DAVResult, DAVResultResponse } from 'webdav'
 
 import { dirname } from '@nextcloud/paths'
-import { XMLBuilder } from 'fast-xml-parser'
-import { parseStat, parseXML } from 'webdav'
 import { RootMetadata } from '../models/RootMetadata.ts'
+import {
+	DAV_NS,
+	getHref,
+	getProperty,
+	getResponses,
+	hasProperties,
+	isCollection,
+	NC_NS,
+	OC_NS,
+	parseMultiStatus,
+	serializeDocument,
+	setProperty,
+} from '../services/davXml.ts'
 import logger from '../services/logger.ts'
 import { decodePath } from '../services/path.ts'
 import * as metadataStore from '../store/metadata.ts'
@@ -27,46 +37,55 @@ export async function usePropFindInterceptor(context: FetchContext, next: () => 
 	context.req.headers.set('X-E2EE-SUPPORTED', 'true')
 	await next()
 	const response = context.res.clone()
-	const path = new URL(context.req.url).pathname
 	const body = await response.text()
-	const xml = await parseXML(body)
-	const stat = parseStat(xml, path, true)
+
+	const document = parseMultiStatus(body)
+	if (document === undefined) {
+		// not a multistatus response, e.g. an error - nothing to replace
+		logger.debug('PROPFIND response is not a multistatus document', { body })
+		return
+	}
+
+	const nodes = getResponses(document)
 
 	// The requested node itself might not be encrypted while the result still contains
 	// encrypted nodes, e.g. when listing an unencrypted folder that contains an e2ee root.
 	// So the encryption state has to be decided for each node individually.
-	const targetIsEncrypted = stat.props !== undefined && String(stat.props['e2ee-is-encrypted']) === '1'
-	const isEncryptedNode = (node: DAVResultResponse): boolean => (
+	const targetPath = trimSlashes(decodePath(new URL(context.req.url).pathname))
+	// the target is the node for the requested path - it is reported first, which is the
+	// fallback in case the server answers with a href we do not recognize as that path
+	const target = nodes.find((node) => nodePath(node) === targetPath) ?? nodes[0]
+	const targetIsEncrypted = target !== undefined && isEncrypted(target)
+	const isEncryptedNode = (node: Element): boolean => (
 		// all nodes within an encrypted PROPFIND target are encrypted as well
-		targetIsEncrypted
-		|| String(node.propstat?.prop['e2ee-is-encrypted']) === '1'
+		targetIsEncrypted || isEncrypted(node)
 	)
 
-	if (!xml.multistatus.response.some(isEncryptedNode)) {
-		logger.debug('No e2ee nodes in PROPFIND result', { xml })
+	if (!nodes.some(isEncryptedNode)) {
+		logger.debug('No e2ee nodes in PROPFIND result', { body })
 		return
 	}
 
-	await cacheMetadataFromPropfind(xml, isEncryptedNode, targetIsEncrypted)
-	await replacePlaceholdersInPropfind(xml, isEncryptedNode)
+	await cacheMetadataFromPropfind(nodes, isEncryptedNode, targetIsEncrypted)
+	await replacePlaceholdersInPropfind(nodes, isEncryptedNode)
 
-	context.res = new Response(new XMLBuilder().build(xml), response)
+	context.res = new Response(serializeDocument(document), response)
 }
 
 /**
  * Cache all e2ee metadata that is shipped as part of the PROPFIND response.
  *
- * @param xml - The XML response
+ * @param nodes - The `d:response` nodes of the XML response
  * @param isEncryptedNode - Whether a given response node is end-to-end encrypted
  * @param targetIsEncrypted - Whether the PROPFIND target itself is end-to-end encrypted
  */
 async function cacheMetadataFromPropfind(
-	xml: DAVResult,
-	isEncryptedNode: (node: DAVResultResponse) => boolean,
+	nodes: Element[],
+	isEncryptedNode: (node: Element) => boolean,
 	targetIsEncrypted: boolean,
 ): Promise<void> {
-	for (const node of xml.multistatus.response) {
-		if (!isEncryptedNode(node) || node.propstat === undefined) {
+	for (const node of nodes) {
+		if (!isEncryptedNode(node) || !hasProperties(node)) {
 			continue
 		}
 
@@ -74,18 +93,15 @@ async function cacheMetadataFromPropfind(
 		// and the name of an e2ee root is not encrypted - so its metadata is only
 		// needed if the response reaches into it. Decrypting it either way would ask
 		// the user for their recovery phrase just to list the folder the root sits in.
-		if (!targetIsEncrypted && !hasContentsInResponse(xml, nodePath(node))) {
-			logger.debug('Skipping metadata of a listed e2ee root', { node })
+		if (!targetIsEncrypted && !hasContentsInResponse(nodes, nodePath(node))) {
+			logger.debug('Skipping metadata of a listed e2ee root', { href: getHref(node) })
 			continue
 		}
 
-		const isFolder = typeof node.propstat.prop?.resourcetype.collection !== 'undefined'
-		const {
-			fileid: fileId,
-			'e2ee-metadata': rawMetadata,
-			'e2ee-metadata-signature': metadataSignature,
-		} = node.propstat.prop as Record<string, string>
-		if (isFolder && fileId && rawMetadata && metadataSignature) {
+		const fileId = getProperty(node, OC_NS, 'fileid')
+		const rawMetadata = getProperty(node, NC_NS, 'e2ee-metadata')
+		const metadataSignature = getProperty(node, NC_NS, 'e2ee-metadata-signature')
+		if (isCollection(node) && fileId && rawMetadata && metadataSignature) {
 			await metadataStore.setRawMetadata(
 				nodePath(node),
 				fileId,
@@ -100,79 +116,78 @@ async function cacheMetadataFromPropfind(
  * Replace the encrypted placeholder names and mimetypes of all encrypted nodes
  * with the real ones from the metadata of their parent folder.
  *
- * @param xml - The XML response
+ * @param nodes - The `d:response` nodes of the XML response
  * @param isEncryptedNode - Whether a given response node is end-to-end encrypted
  */
-async function replacePlaceholdersInPropfind(xml: DAVResult, isEncryptedNode: (node: DAVResultResponse) => boolean): Promise<void> {
-	logger.debug('Updating PROPFIND info', { xml })
+async function replacePlaceholdersInPropfind(nodes: Element[], isEncryptedNode: (node: Element) => boolean): Promise<void> {
+	logger.debug('Updating PROPFIND info', { nodes })
 
 	// Encryption state of all nodes in the response - used to look up whether the parent of a node is encrypted.
 	const encryptedPaths = new Map<string, boolean>()
-	for (const node of xml.multistatus.response) {
+	for (const node of nodes) {
 		encryptedPaths.set(nodePath(node), isEncryptedNode(node))
 	}
 
-	const parsedNodes: DAVResultResponse[] = []
-	for (const node of xml.multistatus.response) {
+	for (const node of nodes) {
 		if (!isEncryptedNode(node)) {
 			// e.g. an unencrypted sibling of an e2ee root - keep it untouched
-			parsedNodes.push(node)
 			continue
 		}
 
-		if (node.propstat === undefined) {
+		if (!hasProperties(node)) {
 			throw new Error('Invalid PROPFIND response: missing propstat')
 		}
 
-		if (node.propstat.prop.permissions) {
+		const permissions = getProperty(node, OC_NS, 'permissions')
+		if (permissions !== undefined) {
 			// remove share permissions as we have internal sharing methods for e2ee
-			node.propstat.prop.permissions = (node.propstat.prop.permissions as string).replace(/R/g, '')
+			setProperty(node, OC_NS, 'permissions', permissions.replace(/R/g, ''))
 		}
 
-		const isFolder = typeof node.propstat.prop?.resourcetype.collection !== 'undefined'
+		const isFolder = isCollection(node)
 		if (!(await hasEncryptedParent(node, isFolder, encryptedPaths))) {
 			// The node is an e2ee root: its name is not encrypted so only the permissions needed adjustment.
-			logger.debug('Node is an e2ee root, skipping PROPFIND replacement', { node })
-			parsedNodes.push(node)
+			logger.debug('Node is an e2ee root, skipping PROPFIND replacement', { href: getHref(node) })
 			continue
 		}
 
 		const { metadata, path: parentPath } = await metadataStore.getMetadata(dirname(nodePath(node)))
-		const identifier = node.propstat.prop.displayname
+		const identifier = getProperty(node, DAV_NS, 'displayname')
 		if (isFolder) {
-			const name = metadata.getFolder(identifier)
+			const name = identifier && metadata.getFolder(identifier)
 			if (!name) {
 				logger.error('Could not find folder in metadata for PROPFIND replacement', { node, identifier, metadata })
+				node.remove()
 				continue
 			}
 
-			node.propstat.prop.displayname = name
-			node.propstat.prop.getcontenttype = 'httpd/unix-directory'
+			setProperty(node, DAV_NS, 'displayname', name)
+			setProperty(node, DAV_NS, 'getcontenttype', 'httpd/unix-directory')
 		} else {
-			const info = metadata.getFile(identifier)
+			const info = identifier ? metadata.getFile(identifier) : undefined
 			if (!info) {
-				if (metadata instanceof RootMetadata && metadata.fileDropEntries.includes(identifier)) {
+				if (identifier && metadata instanceof RootMetadata && metadata.fileDropEntries.includes(identifier)) {
 					logger.debug('File drop entry found for PROPFIND replacement', { node, identifier })
-					if (node.propstat.prop.permissions && (node.propstat.prop.permissions as string).includes('NV')) {
+					if (permissions?.includes('NV')) {
 						// we found a file drop entry and we have permissions to migrate it
 						// so we do not want to block this request any longer but we should
 						// notify the user that this entry needs migration
 						taskStore.addFileDropMigration(parentPath)
 					}
 
+					node.remove()
 					continue
 				}
 
 				logger.error('Could not find file in metadata for PROPFIND replacement', { node, identifier, metadata })
+				node.remove()
 				continue
 			}
 
-			node.propstat.prop.displayname = info.filename
-			node.propstat.prop.getcontenttype = info.mimetype
+			setProperty(node, DAV_NS, 'displayname', info.filename)
+			setProperty(node, DAV_NS, 'getcontenttype', info.mimetype)
 		}
-		parsedNodes.push(node)
 	}
-	xml.multistatus.response = parsedNodes
 }
 
 /**
@@ -184,7 +199,7 @@ async function replacePlaceholdersInPropfind(xml: DAVResult, isEncryptedNode: (n
  * @param isFolder - Whether the node is a folder
  * @param encryptedPaths - Encryption state of all nodes in the response
  */
-async function hasEncryptedParent(node: DAVResultResponse, isFolder: boolean, encryptedPaths: Map<string, boolean>): Promise<boolean> {
+async function hasEncryptedParent(node: Element, isFolder: boolean, encryptedPaths: Map<string, boolean>): Promise<boolean> {
 	const parentState = encryptedPaths.get(dirname(nodePath(node)))
 	if (parentState !== undefined) {
 		return parentState
@@ -204,11 +219,20 @@ async function hasEncryptedParent(node: DAVResultResponse, isFolder: boolean, en
 /**
  * Check whether the response contains any node located inside the given path.
  *
- * @param xml - The XML response
+ * @param nodes - The `d:response` nodes of the XML response
  * @param path - The path of the folder to check
  */
-function hasContentsInResponse(xml: DAVResult, path: string): boolean {
-	return xml.multistatus.response.some((node) => nodePath(node).startsWith(`${path}/`))
+function hasContentsInResponse(nodes: Element[], path: string): boolean {
+	return nodes.some((node) => nodePath(node).startsWith(`${path}/`))
+}
+
+/**
+ * Check whether a response node is end-to-end encrypted.
+ *
+ * @param node - The response node
+ */
+function isEncrypted(node: Element): boolean {
+	return getProperty(node, NC_NS, 'e2ee-is-encrypted') === '1'
 }
 
 /**
@@ -219,6 +243,15 @@ function hasContentsInResponse(xml: DAVResult, path: string): boolean {
  *
  * @param node - The response node
  */
-function nodePath(node: DAVResultResponse): string {
-	return decodePath(node.href.replace(/\/+$/, ''))
+function nodePath(node: Element): string {
+	return trimSlashes(decodePath(getHref(node)))
+}
+
+/**
+ * Remove trailing slashes from a path, as folders are reported with one.
+ *
+ * @param path - The path to trim
+ */
+function trimSlashes(path: string): string {
+	return path.replace(/\/+$/, '')
 }

--- a/src/services/davXml.spec.ts
+++ b/src/services/davXml.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, test } from 'vitest'
+import {
+	DAV_NS,
+	getHref,
+	getProperty,
+	getResponses,
+	hasProperties,
+	isCollection,
+	NC_NS,
+	OC_NS,
+	parseMultiStatus,
+	serializeDocument,
+	setProperty,
+} from './davXml.ts'
+
+const multiStatus = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
+	<d:response>
+		<d:href>/remote.php/dav/files/admin/New%20folder/</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:displayname>New folder</d:displayname>
+				<d:resourcetype><d:collection /></d:resourcetype>
+				<oc:permissions>RGDNVCK</oc:permissions>
+				<nc:e2ee-is-encrypted>1</nc:e2ee-is-encrypted>
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+		<d:propstat>
+			<d:prop>
+				<d:getcontenttype />
+			</d:prop>
+			<d:status>HTTP/1.1 404 Not Found</d:status>
+		</d:propstat>
+	</d:response>
+	<d:response>
+		<d:href>/remote.php/dav/files/admin/New%20folder/file</d:href>
+		<d:propstat>
+			<d:prop>
+				<d:displayname>file</d:displayname>
+				<d:resourcetype />
+			</d:prop>
+			<d:status>HTTP/1.1 200 OK</d:status>
+		</d:propstat>
+	</d:response>
+</d:multistatus>`
+
+/**
+ * Get the response node at the given index of the test document.
+ *
+ * @param index - Index of the response node
+ */
+function response(index: number): Element {
+	return getResponses(parseMultiStatus(multiStatus)!)[index]!
+}
+
+describe('parseMultiStatus', () => {
+	test('parses a multistatus document', () => {
+		const document = parseMultiStatus(multiStatus)
+		expect(document).toBeDefined()
+		expect(getResponses(document!)).toHaveLength(2)
+	})
+
+	test.for([
+		['invalid XML', '<d:multistatus'],
+		['an empty body', ''],
+		['a plain text body', 'Not found'],
+		['another document', '<d:error xmlns:d="DAV:"><s:message /></d:error>'],
+	])('rejects %s', ([, body]) => {
+		expect(parseMultiStatus(body!)).toBeUndefined()
+	})
+})
+
+describe('getProperty', () => {
+	test('reads a property', () => {
+		expect(getProperty(response(0), DAV_NS, 'displayname')).toBe('New folder')
+		expect(getProperty(response(0), OC_NS, 'permissions')).toBe('RGDNVCK')
+		expect(getProperty(response(0), NC_NS, 'e2ee-is-encrypted')).toBe('1')
+	})
+
+	test('does not read a property of another namespace', () => {
+		expect(getProperty(response(0), NC_NS, 'displayname')).toBeUndefined()
+	})
+
+	test('does not read an unavailable property', () => {
+		// the content type is only part of the failed propstat
+		expect(getProperty(response(0), DAV_NS, 'getcontenttype')).toBeUndefined()
+	})
+})
+
+describe('setProperty', () => {
+	test('replaces an available property', () => {
+		const node = response(0)
+		setProperty(node, DAV_NS, 'displayname', 'Vacation')
+		expect(getProperty(node, DAV_NS, 'displayname')).toBe('Vacation')
+		expect(serializeDocument(node.ownerDocument)).toContain('<d:displayname>Vacation</d:displayname>')
+	})
+
+	test('escapes the new value', () => {
+		const node = response(0)
+		setProperty(node, DAV_NS, 'displayname', 'a & b <c>')
+		expect(serializeDocument(node.ownerDocument)).toContain('<d:displayname>a &amp; b &lt;c&gt;</d:displayname>')
+	})
+
+	test('moves an unavailable property over to the available ones', () => {
+		const node = response(0)
+		setProperty(node, DAV_NS, 'getcontenttype', 'httpd/unix-directory')
+
+		expect(getProperty(node, DAV_NS, 'getcontenttype')).toBe('httpd/unix-directory')
+		// the property is gone from the failed propstat, as it does have a value now
+		const failed = node.ownerDocument.evaluate(
+			'count(//*[local-name()="status"][contains(text(),"404")]/../*[local-name()="prop"]/*)',
+			node.ownerDocument,
+			null,
+			XPathResult.NUMBER_TYPE,
+		)
+		expect(failed.numberValue).toBe(0)
+	})
+
+	test('creates a missing property with the prefix of the document', () => {
+		const node = response(1)
+		setProperty(node, OC_NS, 'permissions', 'GDNVW')
+
+		expect(getProperty(node, OC_NS, 'permissions')).toBe('GDNVW')
+		expect(serializeDocument(node.ownerDocument)).toContain('<oc:permissions>GDNVW</oc:permissions>')
+	})
+})
+
+describe('response helpers', () => {
+	test('reads the href', () => {
+		expect(getHref(response(0))).toBe('/remote.php/dav/files/admin/New%20folder/')
+	})
+
+	test('detects folders', () => {
+		expect(isCollection(response(0))).toBe(true)
+		expect(isCollection(response(1))).toBe(false)
+	})
+
+	test('detects available properties', () => {
+		expect(hasProperties(response(0))).toBe(true)
+	})
+})
+
+describe('serializeDocument', () => {
+	test('keeps an untouched document as it is', () => {
+		const document = parseMultiStatus(multiStatus)!
+		// empty elements are collapsed and the whitespace of the prolog is dropped,
+		// but nothing of the content itself may change
+		expect(serializeDocument(document)).toBe(multiStatus.replace('?>\n', '?>').replaceAll(' />', '/>'))
+	})
+
+	test('always emits an XML declaration', () => {
+		const document = parseMultiStatus(multiStatus.split('\n').slice(1).join('\n'))!
+		expect(serializeDocument(document)).toContain('<?xml version="1.0"?>')
+	})
+})

--- a/src/services/davXml.ts
+++ b/src/services/davXml.ts
@@ -1,0 +1,207 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Helpers to edit a WebDAV `multistatus` response in place.
+ *
+ * Interceptors have to hand the response on to whoever made the request, so the
+ * document must survive the detour unchanged apart from the properties we
+ * actually replace. Parsing it into a plain object and building a new document
+ * from that does not do that: it drops namespace prefixes, turns attributes into
+ * elements, coerces values into numbers and merges the `propstat` blocks.
+ *
+ * So the document is edited as a DOM tree instead - everything we do not touch is
+ * serialized back exactly as the server sent it.
+ */
+
+/** Namespace of the WebDAV properties */
+export const DAV_NS = 'DAV:'
+
+/** Namespace of the ownCloud specific properties */
+export const OC_NS = 'http://owncloud.org/ns'
+
+/** Namespace of the Nextcloud specific properties */
+export const NC_NS = 'http://nextcloud.org/ns'
+
+/**
+ * Parse a WebDAV `multistatus` document.
+ *
+ * Returns `undefined` if the body is not one - it might be invalid XML, an empty
+ * body or a `d:error` document, none of which we want to touch.
+ *
+ * @param body - The raw response body
+ */
+export function parseMultiStatus(body: string): Document | undefined {
+	// invalid XML yields a `parsererror` document instead of throwing,
+	// which is covered by the check for the expected root element below
+	const document = new DOMParser().parseFromString(body, 'application/xml')
+	const root = document.documentElement
+	if (root.namespaceURI !== DAV_NS || root.localName !== 'multistatus') {
+		return undefined
+	}
+
+	return document
+}
+
+/**
+ * Serialize a document back into a response body.
+ *
+ * @param document - The document to serialize
+ */
+export function serializeDocument(document: Document): string {
+	const body = new XMLSerializer().serializeToString(document)
+	// The XML declaration is not part of the DOM tree: Chromium keeps the one of the
+	// parsed document, other engines drop it. It is optional, but adding it back keeps
+	// the response as close to the original as possible.
+	return body.startsWith('<?xml') ? body : `<?xml version="1.0"?>\n${body}`
+}
+
+/**
+ * Get all `d:response` elements of a `multistatus` document.
+ *
+ * @param document - The `multistatus` document
+ */
+export function getResponses(document: Document): Element[] {
+	return childElements(document.documentElement, DAV_NS, 'response')
+}
+
+/**
+ * Get the `d:href` of a response - percent-encoded, as sent by the server.
+ *
+ * @param response - The `d:response` element
+ */
+export function getHref(response: Element): string {
+	return childElements(response, DAV_NS, 'href')[0]?.textContent ?? ''
+}
+
+/**
+ * Check whether the server returned any property for the given response,
+ * meaning its properties can be read and replaced.
+ *
+ * @param response - The `d:response` element
+ */
+export function hasProperties(response: Element): boolean {
+	return availableProperties(response) !== undefined
+}
+
+/**
+ * Get the value of a property the server did return for the given response.
+ *
+ * Returns `undefined` if the property is not part of the response or was reported
+ * as unavailable, so a missing property can be told apart from an empty one.
+ *
+ * @param response - The `d:response` element
+ * @param namespace - Namespace of the property
+ * @param name - Local name of the property
+ */
+export function getProperty(response: Element, namespace: string, name: string): string | undefined {
+	const properties = availableProperties(response)
+	if (properties === undefined) {
+		return undefined
+	}
+
+	return childElements(properties, namespace, name)[0]?.textContent ?? undefined
+}
+
+/**
+ * Set the value of a property of the given response.
+ *
+ * A property the server reported as unavailable - like the content type of a
+ * folder - is moved over to the successful `d:propstat`, as it does have a value
+ * now. A property that is missing entirely is created.
+ *
+ * @param response - The `d:response` element
+ * @param namespace - Namespace of the property
+ * @param name - Local name of the property
+ * @param value - The value to set
+ */
+export function setProperty(response: Element, namespace: string, name: string, value: string): void {
+	const properties = availableProperties(response)
+	if (properties === undefined) {
+		throw new Error('Invalid PROPFIND response: no successful propstat')
+	}
+
+	let property = childElements(properties, namespace, name)[0]
+	if (property === undefined) {
+		property = unavailableProperties(response)
+			.flatMap((unavailable) => childElements(unavailable, namespace, name))[0]
+			?? createProperty(response.ownerDocument, namespace, name)
+		properties.append(property)
+	}
+
+	property.textContent = value
+}
+
+/**
+ * Check whether a response describes a folder.
+ *
+ * @param response - The `d:response` element
+ */
+export function isCollection(response: Element): boolean {
+	const properties = availableProperties(response)
+	const resourcetype = properties && childElements(properties, DAV_NS, 'resourcetype')[0]
+	return resourcetype !== undefined && childElements(resourcetype, DAV_NS, 'collection').length > 0
+}
+
+/**
+ * Get the `d:prop` element holding the properties the server did return,
+ * or `undefined` if the response has no successful `d:propstat` at all.
+ *
+ * @param response - The `d:response` element
+ */
+function availableProperties(response: Element): Element | undefined {
+	const propstat = childElements(response, DAV_NS, 'propstat').find(isSuccessful)
+	return propstat && childElements(propstat, DAV_NS, 'prop')[0]
+}
+
+/**
+ * Get the `d:prop` elements holding the properties the server did not return,
+ * e.g. because they do not apply to the resource - those elements are empty.
+ *
+ * @param response - The `d:response` element
+ */
+function unavailableProperties(response: Element): Element[] {
+	return childElements(response, DAV_NS, 'propstat')
+		.filter((propstat) => !isSuccessful(propstat))
+		.flatMap((propstat) => childElements(propstat, DAV_NS, 'prop'))
+}
+
+/**
+ * Check whether a `d:propstat` reports its properties as available.
+ *
+ * @param propstat - The `d:propstat` element
+ */
+function isSuccessful(propstat: Element): boolean {
+	const status = childElements(propstat, DAV_NS, 'status')[0]?.textContent ?? ''
+	return /\s2\d\d(\s|$)/.test(status)
+}
+
+/**
+ * Create a property element, reusing the namespace prefix of the document so the
+ * new element does not need a namespace declaration of its own.
+ *
+ * @param document - The document to create the element for
+ * @param namespace - Namespace of the property
+ * @param name - Local name of the property
+ */
+function createProperty(document: Document, namespace: string, name: string): Element {
+	const prefix = document.documentElement.lookupPrefix(namespace)
+	return document.createElementNS(namespace, prefix ? `${prefix}:${name}` : name)
+}
+
+/**
+ * Get all direct child elements with the given namespace and local name.
+ *
+ * The DOM is queried by namespace instead of by tag name, as the prefixes are
+ * chosen by the server and only their namespaces are part of the protocol.
+ *
+ * @param parent - The element to get the children of
+ * @param namespace - Namespace of the children
+ * @param name - Local name of the children
+ */
+function childElements(parent: Element, namespace: string, name: string): Element[] {
+	return Array.from(parent.children)
+		.filter((child) => child.namespaceURI === namespace && child.localName === name)
+}


### PR DESCRIPTION
Before we were using XML -> JS object -> XML conversion for the propfind interceptor to handle value replacements.
This does not properly work for props with attributes as after a round trip `<a b />` results in `<a><@b /></a>` which is not the same XML.

So instead of the full propfind parsing we use real XML parsing here into a document, change values and serlialize back to XML without loosing precision.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
