### PR TITLE
fix(OCP): Move away from deprecated RedirectToDefaultAppResponse

### DIFF
--- a/lib/Middleware/CanUseAppMiddleware.php
+++ b/lib/Middleware/CanUseAppMiddleware.php
@@ -12,7 +12,7 @@ use OCA\EndToEndEncryption\Config;
 use OCA\EndToEndEncryption\Middleware\Exceptions\CanNotUseAppException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\RedirectResponse
+use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\OCS\OCSException;

--- a/lib/Middleware/CanUseAppMiddleware.php
+++ b/lib/Middleware/CanUseAppMiddleware.php
@@ -12,11 +12,12 @@ use OCA\EndToEndEncryption\Config;
 use OCA\EndToEndEncryption\Middleware\Exceptions\CanNotUseAppException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\RedirectToDefaultAppResponse;
+use OCP\AppFramework\Http\RedirectResponse
 use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCSController;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 
@@ -24,6 +25,7 @@ class CanUseAppMiddleware extends Middleware {
 	public function __construct(
 		private readonly IUserSession $userSession,
 		private readonly Config $config,
+		private readonly IURLGenerator $url,
 	) {
 	}
 
@@ -51,7 +53,7 @@ class CanUseAppMiddleware extends Middleware {
 				throw new OCSException($exception->getMessage(), Http::STATUS_FORBIDDEN);
 			}
 
-			return new RedirectToDefaultAppResponse();
+			return new RedirectResponse($this->url->linkToDefaultPageUrl());
 		}
 
 		throw $exception;


### PR DESCRIPTION
Deprecated >3y ago. Last in project app referencing it.

https://github.com/nextcloud/server/blob/476975002611fc9c8931ea33b6c4d559438e04b7/lib/public/AppFramework/Http/RedirectToDefaultAppResponse.php#L31

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
